### PR TITLE
feat: add required before optional in interface type rule

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -8,6 +8,7 @@ const plugin = {
     "enforce-interface-type-naming": require("./rules/enforce-interface-type-naming"),
     "no-default-export": require("./rules/no-default-export"),
     "no-inline-arrow-functions-in-jsx": require("./rules/no-inline-arrow-functions-in-jsx"),
+    "interface-type-required-first": require("./rules/interface-type-required-first"),
   },
 };
 
@@ -25,6 +26,7 @@ plugin.configs = {
       "eslint-frontend-rules/enforce-interface-type-naming": "error",
       "eslint-frontend-rules/no-default-export": "error",
       "eslint-frontend-rules/no-inline-arrow-functions-in-jsx": "warn",
+      "eslint-frontend-rules/interface-type-required-first": "error",
     },
   },
 };

--- a/lib/rules/interface-type-required-first.js
+++ b/lib/rules/interface-type-required-first.js
@@ -35,19 +35,14 @@ const rule = {
       if (micromatch.isMatch(filename, ignorePatterns)) return {};
     }
     function checkFields(node, parentName) {
-      // For TSInterfaceDeclaration: node.body.body is the array of members
-      // For TSTypeAliasDeclaration: node.typeAnnotation.body is the array of members
       let members = [];
-
-      if (node.body && Array.isArray(node.body)) {
-        members = node.body;
-      } else if (node.body && Array.isArray(node.body.body)) {
+      // For TSInterfaceDeclaration: node.body.body is the array of members
+      if (node.body && Array.isArray(node.body.body)) {
         members = node.body.body;
-      } else if (
-        node.typeAnnotation &&
-        Array.isArray(node.typeAnnotation.body)
-      ) {
-        members = node.typeAnnotation.body;
+      } else if (node.body && Array.isArray(node.body)) {
+        members = node.body;
+      } else if (node.members && Array.isArray(node.members)) {
+        members = node.members;
       }
       // If no members, nothing to check
       if (!members.length) return;

--- a/lib/rules/interface-type-required-first.js
+++ b/lib/rules/interface-type-required-first.js
@@ -1,0 +1,92 @@
+// ESLint rule: Enforce that in TypeScript interfaces and types, all optional fields come after required fields.
+
+const rule = {
+  meta: {
+    type: "suggestion",
+    docs: {
+      description:
+        "Require all required fields to come before optional fields in interfaces and types.",
+      category: "Best Practices",
+    },
+    messages: {
+      requiredBeforeOptional:
+        "Required field '{{name}}' should come before all optional fields in '{{parent}}'.",
+    },
+    schema: [
+      {
+        type: "object",
+        properties: {
+          ignore: {
+            type: "array",
+            items: { type: "string" },
+          },
+        },
+        additionalProperties: false,
+      },
+    ],
+  },
+  create(context) {
+    const filename = context.getFilename();
+    if (!filename.endsWith(".ts") && !filename.endsWith(".tsx")) return {};
+    const options = context.options[0] || {};
+    const ignorePatterns = options.ignore || [];
+    if (ignorePatterns.length) {
+      const micromatch = require("micromatch");
+      if (micromatch.isMatch(filename, ignorePatterns)) return {};
+    }
+    function checkFields(node, parentName) {
+      // For TSInterfaceDeclaration: node.body.body is the array of members
+      // For TSTypeAliasDeclaration: node.typeAnnotation.body is the array of members
+      let members = [];
+
+      if (node.body && Array.isArray(node.body)) {
+        members = node.body;
+      } else if (node.body && Array.isArray(node.body.body)) {
+        members = node.body.body;
+      } else if (
+        node.typeAnnotation &&
+        Array.isArray(node.typeAnnotation.body)
+      ) {
+        members = node.typeAnnotation.body;
+      }
+      // If no members, nothing to check
+      if (!members.length) return;
+      let foundOptional = false;
+      for (const member of members) {
+        // Check if the member is a property signature with a name
+        if (
+          member.type !== "TSPropertySignature" ||
+          !member.key ||
+          !member.key.name
+        )
+          continue;
+        const isOptional = !!member.optional;
+        if (isOptional) {
+          foundOptional = true;
+        } else if (foundOptional) {
+          // Found a required field after an optional field
+          context.report({
+            node: member.key,
+            messageId: "requiredBeforeOptional",
+            data: { name: member.key.name, parent: parentName },
+          });
+        }
+      }
+    }
+    return {
+      TSInterfaceDeclaration(node) {
+        checkFields(node.body, node.id.name);
+      },
+      TSTypeAliasDeclaration(node) {
+        if (
+          node.typeAnnotation &&
+          node.typeAnnotation.type === "TSTypeLiteral"
+        ) {
+          checkFields(node.typeAnnotation, node.id.name);
+        }
+      },
+    };
+  },
+};
+
+module.exports = rule;

--- a/lib/rules/no-direct-colors.js
+++ b/lib/rules/no-direct-colors.js
@@ -35,9 +35,6 @@ module.exports = {
     const ignorePatterns = options.ignore || [];
     if (ignorePatterns.length && micromatch.isMatch(filename, ignorePatterns))
       return {};
-    console.log(
-      `Checking file: ${filename} for direct color values in styles or classNames`
-    );
     function checkValue(node, value) {
       if (typeof value === "string" && COLOR_REGEX.test(value)) {
         context.report({ node, messageId: "noDirectColor" });

--- a/lib/rules/no-focusable-non-interactive-elements.js
+++ b/lib/rules/no-focusable-non-interactive-elements.js
@@ -85,9 +85,6 @@ const rule = {
             attr.name &&
             attr.name.name === "onKeyDown"
         );
-        console.log(
-          `Checking <${tag}>: hasOnClick=${hasOnClick}, hasRoleButton=${hasRoleButton}, hasOnKeyDown=${hasOnKeyDown}`
-        );
         if (!hasRoleButton && !hasOnKeyDown) {
           context.report({
             node,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-frontend-rules",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Reusable ESLint plugin for frontend projects: enforces consistent naming, design, and code quality rules for React and TypeScript, including Typography components, color usage, file naming, export style, and more.",
   "main": "lib/index.js",
   "keywords": [


### PR DESCRIPTION
## Add ESLint Rule: interface-type-required-first

This PR adds a new rule, `interface-type-required-first`, to the `eslint-frontend-rules` plugin.

### What does it do?

Enforces that in TypeScript interfaces and type aliases, all required fields must come before any optional fields. This maintains a consistent and readable structure for type definitions, making it clear which fields are always present and which are optional.

### Features

- **Supports both interfaces and type aliases:**  
  Checks `TSInterfaceDeclaration` and `TSTypeAliasDeclaration` nodes.
- **Reports required fields after optional fields:**  
  Ensures all required fields are listed first.
- **Configurable ignore patterns:**  
  Allows skipping files using glob patterns.

### Example

```ts
interface User {
  id: string;         // required
  name?: string;      // optional
  email: string;      // required ❌ (will be reported)
}