### PR TITLE
feat: add enforce-alias-import-paths rule to plugin and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,31 @@ Add `eslint-frontend-rules` to your ESLint config:
 
 - Options: `ignore` (array of glob patterns)
 
+### 9. enforce-alias-import-paths
+
+**Enforces the use of alias import paths instead of relative paths (e.g., '@/components/Button' instead of '../../components/Button').**
+
+- Helps maintain consistent and readable import statements by requiring configured alias prefixes.
+- Default allowed alias: `@`. You can configure more aliases in your ESLint config.
+- Options:
+  - `aliases`: Array of allowed alias prefixes for import paths (e.g., `['@', '@components', '@utils']`).
+  - `ignore`: Array of glob patterns to ignore files or import paths.
+
+**Example configuration:**
+
+```js
+// .eslintrc.js
+rules: {
+  'eslint-frontend-rules/enforce-alias-import-paths': [
+    'error',
+    {
+      aliases: ['@', '@components', '@utils'],
+      ignore: ['**/*.test.tsx']
+    }
+  ]
+}
+```
+
 ## Example: Custom Rule Options
 
 ```json
@@ -107,6 +132,13 @@ Add `eslint-frontend-rules` to your ESLint config:
     "eslint-frontend-rules/no-inline-arrow-functions-in-jsx": [
       "warn",
       { "ignore": ["**/storybook/**"] }
+    ],
+    "eslint-frontend-rules/enforce-alias-import-paths": [
+      "error",
+      {
+        "aliases": ["@"],
+        "ignore": ["**/node_modules/**"]
+      }
     ]
   }
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -9,6 +9,7 @@ const plugin = {
     "no-default-export": require("./rules/no-default-export"),
     "no-inline-arrow-functions-in-jsx": require("./rules/no-inline-arrow-functions-in-jsx"),
     "interface-type-required-first": require("./rules/interface-type-required-first"),
+    "enforce-alias-import-paths": require("./rules/enforce-alias-import-paths"),
   },
 };
 
@@ -25,8 +26,9 @@ plugin.configs = {
       "eslint-frontend-rules/enforce-kebab-case-filenames": "error",
       "eslint-frontend-rules/enforce-interface-type-naming": "error",
       "eslint-frontend-rules/no-default-export": "error",
-      "eslint-frontend-rules/no-inline-arrow-functions-in-jsx": "warn",
       "eslint-frontend-rules/interface-type-required-first": "error",
+      "eslint-frontend-rules/no-inline-arrow-functions-in-jsx": "warn",
+      "eslint-frontend-rules/enforce-alias-import-paths": "warn",
     },
   },
 };

--- a/lib/rules/enforce-alias-import-paths.js
+++ b/lib/rules/enforce-alias-import-paths.js
@@ -1,0 +1,94 @@
+/**
+ * @fileoverview Enforces use of alias import paths instead of relative paths.
+ *
+ * This rule helps maintain consistent and readable import statements in your codebase by requiring the use of configured alias prefixes (e.g., '@/components/Button') rather than relative paths (e.g., '../../components/Button').
+ *
+ * Configuration:
+ * You can specify allowed alias prefixes and ignore patterns in your ESLint configuration file.
+ *
+ * Example (.eslintrc.js):
+ *
+ *   rules: {
+ *     'eslint-frontend-rules/enforce-alias-import-paths': [
+ *       'error',
+ *       {
+ *         aliases: ['@', '@components', '@utils'],
+ *         ignore: ['*.test.tsx']
+ *       }
+ *     ]
+ *   }
+ *
+ * - aliases: Array of allowed alias prefixes for import paths.
+ * - ignore: Array of glob patterns to ignore files or import paths.
+ *
+ * By default, the rule allows the '@' alias.
+ */
+
+const DEFAULT_ALIASES = ["@"];
+
+const rule = {
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Enforce use of alias import paths instead of relative paths. Supports configuration of allowed aliases and ignore patterns in your ESLint config.",
+      category: "Best Practices",
+    },
+    messages: {
+      noRelativeImport:
+        'Relative import path "{{importPath}}" detected. Use an alias import path (e.g., {{aliases}}) instead.',
+    },
+    schema: [
+      {
+        type: "object",
+        properties: {
+          aliases: {
+            type: "array",
+            items: { type: "string" },
+          },
+          ignore: {
+            type: "array",
+            items: { type: "string" },
+          },
+        },
+        additionalProperties: false,
+      },
+    ],
+  },
+  create(context) {
+    const filename = context.getFilename();
+    const options = context.options[0] || {};
+    const aliases = options.aliases || DEFAULT_ALIASES;
+    const ignorePatterns = options.ignore || [];
+    let micromatch;
+    if (ignorePatterns.length) {
+      micromatch = require("micromatch");
+      if (micromatch.isMatch(filename, ignorePatterns)) return {};
+    }
+    return {
+      ImportDeclaration(node) {
+        const importPath = node.source.value;
+        if (typeof importPath !== "string") return;
+        // Ignore node_modules and package imports
+        if (!importPath.startsWith(".") && !importPath.startsWith("/")) return;
+        // Ignore if matches ignorePatterns
+        if (micromatch && micromatch.isMatch(importPath, ignorePatterns))
+          return;
+        // Check if path starts with alias
+
+        if (aliases.some((alias) => importPath.startsWith(alias))) return;
+        // Flag relative import
+        context.report({
+          node: node.source,
+          messageId: "noRelativeImport",
+          data: {
+            importPath,
+            aliases: aliases.join(", "),
+          },
+        });
+      },
+    };
+  },
+};
+
+module.exports = rule;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-frontend-rules",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Reusable ESLint plugin for frontend projects: enforces consistent naming, design, and code quality rules for React and TypeScript, including Typography components, color usage, file naming, export style, and more.",
   "main": "lib/index.js",
   "keywords": [


### PR DESCRIPTION
## Add `enforce-alias-import-paths` Rule to ESLint Frontend Plugin

### Overview
This PR introduces the `enforce-alias-import-paths` rule to the `eslint-frontend-rules` plugin. The new rule enforces the use of alias import paths (such as `@/components/Button`) instead of deep relative paths (like `../../components/Button`), improving codebase consistency and maintainability.

### Features
- **Configurable Aliases:** Users can specify allowed alias prefixes via the ESLint config (`aliases` option).
- **Ignore Patterns:** Supports glob patterns to ignore specific files or import paths (`ignore` option).
- **Default Behavior:** The rule allows the `@` alias by default.
- **Documentation:** JSDoc and README updated with configuration instructions and usage examples.
- **Package Metadata:** `package.json` updated to reflect the new rule and maintain npm publishing standards.

### Example Configuration
```js
// .eslintrc.js
rules: {
  'eslint-frontend-rules/enforce-alias-import-paths': [
    'error',
    {
      aliases: ['@', '@components', '@utils'],
      ignore: ['**/*.test.tsx']
    }
  ]
}