### PR TITLE
feat: add no-nested-component rule to prevent inner component definitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,20 @@ rules: {
 }
 ```
 
+### 10. no-nested-component
+
+**Disallows defining a new component inside another component.**
+
+- Prevents declaring a React component (function or class) inside the body of another component.
+- All components should be defined at the top level of the file for performance and maintainability.
+- Error: Do not define a new component inside another component. Move it to the top level of the file.
+- Options: `ignore` (array of glob patterns)
+
+**Why?**
+
+- Inner components are recreated on every render, breaking memoization and harming performance.
+- Encourages clear, maintainable code structure.
+
 ## Example: Custom Rule Options
 
 ```json

--- a/lib/index.js
+++ b/lib/index.js
@@ -10,6 +10,7 @@ const plugin = {
     "no-inline-arrow-functions-in-jsx": require("./rules/no-inline-arrow-functions-in-jsx"),
     "interface-type-required-first": require("./rules/interface-type-required-first"),
     "enforce-alias-import-paths": require("./rules/enforce-alias-import-paths"),
+    "no-nested-component": require("./rules/no-nested-component"),
   },
 };
 
@@ -29,6 +30,7 @@ plugin.configs = {
       "eslint-frontend-rules/interface-type-required-first": "error",
       "eslint-frontend-rules/no-inline-arrow-functions-in-jsx": "warn",
       "eslint-frontend-rules/enforce-alias-import-paths": "warn",
+      "eslint-frontend-rules/no-nested-component": "error",
     },
   },
 };

--- a/lib/rules/no-nested-component.js
+++ b/lib/rules/no-nested-component.js
@@ -1,0 +1,152 @@
+/**
+ * @fileoverview Disallow defining a new component inside another component.
+ *
+ * This rule prevents declaring a React component (function or class) inside the body of another component. All components should be defined at the top level of the file for performance and maintainability.
+ *
+ * Why?
+ * - Inner components are recreated on every render, breaking memoization and harming performance.
+ * - Encourages clear, maintainable code structure.
+ *
+ * Configuration:
+ * - `ignore`: Array of glob patterns to ignore files.
+ */
+
+const rule = {
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Disallow defining a new component inside another component.",
+      category: "Best Practices",
+    },
+    messages: {
+      noNestedComponent:
+        "Do not define a new component inside another component. Move '{{name}}' to the top level of the file.",
+    },
+    schema: [
+      {
+        type: "object",
+        properties: {
+          ignore: {
+            type: "array",
+            items: { type: "string" },
+          },
+        },
+        additionalProperties: false,
+      },
+    ],
+  },
+  create(context) {
+    const options = context.options[0] || {};
+    const ignorePatterns = options.ignore || [];
+    let micromatch;
+    if (ignorePatterns.length) {
+      micromatch = require("micromatch");
+      const filename = context.getFilename();
+      if (micromatch.isMatch(filename, ignorePatterns)) return {};
+    }
+    // Helper: is a function/class a React component?
+    function isComponent(node) {
+      if (
+        node.type === "FunctionDeclaration" ||
+        node.type === "FunctionExpression" ||
+        node.type === "ArrowFunctionExpression"
+      ) {
+        // Heuristic: name starts with uppercase, or returns JSX
+        if (node.id && /^[A-Z]/.test(node.id.name)) return true;
+        if (
+          node.parent &&
+          node.parent.type === "VariableDeclarator" &&
+          /^[A-Z]/.test(node.parent.id.name)
+        )
+          return true;
+        // Returns JSX (JSXElement or JSXFragment)
+        if (node.body && node.body.type === "BlockStatement") {
+          return node.body.body.some(
+            (stmt) =>
+              stmt.type === "ReturnStatement" &&
+              stmt.argument &&
+              (stmt.argument.type === "JSXElement" ||
+                stmt.argument.type === "JSXFragment")
+          );
+        }
+      }
+      if (
+        node.type === "ClassDeclaration" &&
+        node.id &&
+        /^[A-Z]/.test(node.id.name)
+      ) {
+        return true;
+      }
+      return false;
+    }
+    // Track component nesting
+    let componentStack = [];
+    return {
+      FunctionDeclaration(node) {
+        if (isComponent(node)) {
+          if (componentStack.length > 0) {
+            context.report({
+              node,
+              messageId: "noNestedComponent",
+              data: { name: node.id ? node.id.name : "(anonymous)" },
+            });
+          }
+          componentStack.push(node);
+        }
+      },
+      "FunctionDeclaration:exit"(node) {
+        if (isComponent(node)) {
+          componentStack.pop();
+        }
+      },
+      ClassDeclaration(node) {
+        if (isComponent(node)) {
+          if (componentStack.length > 0) {
+            context.report({
+              node,
+              messageId: "noNestedComponent",
+              data: { name: node.id ? node.id.name : "(anonymous)" },
+            });
+          }
+          componentStack.push(node);
+        }
+      },
+      "ClassDeclaration:exit"(node) {
+        if (isComponent(node)) {
+          componentStack.pop();
+        }
+      },
+      // For arrow functions assigned to variables
+      VariableDeclarator(node) {
+        if (
+          node.init &&
+          (node.init.type === "ArrowFunctionExpression" ||
+            node.init.type === "FunctionExpression") &&
+          /^[A-Z]/.test(node.id.name)
+        ) {
+          if (componentStack.length > 0) {
+            context.report({
+              node,
+              messageId: "noNestedComponent",
+              data: { name: node.id.name },
+            });
+          }
+          componentStack.push(node);
+        }
+      },
+      "VariableDeclarator:exit"(node) {
+        if (
+          node.init &&
+          (node.init.type === "ArrowFunctionExpression" ||
+            node.init.type === "FunctionExpression") &&
+          /^[A-Z]/.test(node.id.name)
+        ) {
+          componentStack.pop();
+        }
+      },
+    };
+  },
+};
+
+module.exports = rule;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-frontend-rules",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Reusable ESLint plugin for frontend projects: enforces consistent naming, design, and code quality rules for React and TypeScript, including Typography components, color usage, file naming, export style, and more.",
   "main": "lib/index.js",
   "keywords": [


### PR DESCRIPTION
## Add `no-nested-component` Rule to ESLint Frontend Plugin

### Overview
This PR introduces the `no-nested-component` rule to the `eslint-frontend-rules` plugin. The rule prevents defining a new React component (function or class) inside another component, enforcing best practices for code structure and performance.

### Features
- **Prevents Nested Component Definitions:** Flags any React component declared inside another component's body.
- **Promotes Top-Level Component Declarations:** Ensures all components are defined at the top level of the file.
- **Configurable Ignore Patterns:** Supports an `ignore` option for glob patterns to exclude specific files.
- **Documentation:** README and JSDoc updated with rule details, rationale, and configuration instructions.
- **Package Update:** Version bumped to `1.0.4` in `package.json`.

### Example Configuration
```js
// .eslintrc.js
rules: {
  'eslint-frontend-rules/no-nested-component': [
    'error',
    {
      ignore: ['**/*.test.tsx']
    }
  ]
}