### PR TITLE
feat: add no-unnecessary-fragment rule to warn against redundant React fragments

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,46 @@ rules: {
 - Inner components are recreated on every render, breaking memoization and harming performance.
 - Encourages clear, maintainable code structure.
 
+### 11. no-unnecessary-fragment
+
+**Warns if React fragments (`<>...</>`, `<React.Fragment>...</React.Fragment>`, or `<Fragment>...</Fragment>`) are unnecessary.**
+
+- Warns when a fragment wraps only a single child or is not needed for grouping.
+- Supports both short syntax (`<>...</>`) and named fragments (`<React.Fragment>`, `<Fragment>`).
+- Helps keep JSX clean and readable by removing redundant fragments.
+- No options.
+
+**Example:**
+
+```jsx
+// Warns:
+return (
+  <>
+    <div />
+  </>
+);
+
+return (
+  <Fragment>
+    <div />
+  </Fragment>
+);
+
+return (
+  <React.Fragment>
+    <div />
+  </React.Fragment>
+);
+
+// OK:
+return (
+  <>
+    <div />
+    <span />
+  </>
+);
+```
+
 ## Example: Custom Rule Options
 
 ```json

--- a/lib/index.js
+++ b/lib/index.js
@@ -18,6 +18,7 @@ const plugin = {
     // React
     "no-inline-arrow-functions-in-jsx": require("./rules/react/no-inline-arrow-functions-in-jsx"),
     "no-nested-component": require("./rules/react/no-nested-component"),
+    "no-unnecessary-fragment": require("./rules/react/no-unnecessary-fragment"),
   },
 };
 
@@ -38,6 +39,7 @@ plugin.configs = {
       "eslint-frontend-rules/no-inline-arrow-functions-in-jsx": "warn",
       "eslint-frontend-rules/enforce-alias-import-paths": "warn",
       "eslint-frontend-rules/no-nested-component": "error",
+      "eslint-frontend-rules/no-unnecessary-fragment": "warn",
     },
   },
 };

--- a/lib/rules/react/no-unnecessary-fragment.js
+++ b/lib/rules/react/no-unnecessary-fragment.js
@@ -1,0 +1,54 @@
+/**
+ * @fileoverview Warns if React fragments (<>...</> or <React.Fragment>...</React.Fragment>) are unnecessary.
+ *
+ * This rule checks for unnecessary fragments in JSX. If a fragment wraps a single child or is not needed for grouping, it warns the user.
+ *
+ * Why? Unnecessary fragments add noise to the code and can be safely removed for clarity.
+ */
+
+const {
+  getMeaningfulChildren,
+  isFragmentElement,
+} = require("../../utils/fragment-helpers");
+
+const rule = {
+  meta: {
+    type: "suggestion",
+    docs: {
+      description:
+        "Warn if React fragments are unnecessary (e.g., wrapping a single child).",
+      category: "Best Practices",
+    },
+    messages: {
+      unnecessaryFragment:
+        "Unnecessary React fragment: consider removing the fragment wrapper.",
+    },
+    schema: [],
+  },
+  create(context) {
+    return {
+      JSXFragment(node) {
+        const children = getMeaningfulChildren(node.children);
+        if (children.length === 1 && children[0].type !== "JSXFragment") {
+          context.report({
+            node,
+            messageId: "unnecessaryFragment",
+          });
+        }
+      },
+      JSXElement(node) {
+        if (isFragmentElement(node)) {
+          const children = getMeaningfulChildren(node.children);
+          if (children.length === 1 && children[0].type !== "JSXFragment") {
+            context.report({
+              node,
+              messageId: "unnecessaryFragment",
+            });
+          }
+        }
+      },
+    };
+  },
+};
+
+module.exports = rule;

--- a/lib/utils/fragment-helpers.js
+++ b/lib/utils/fragment-helpers.js
@@ -1,0 +1,49 @@
+/**
+ * Utility functions for React fragment lint rules.
+ */
+
+function getMeaningfulChildren(children) {
+  return children.filter((child) => {
+    if (child.type === "JSXText") return child.value.trim() !== "";
+    if (
+      child.type === "JSXExpressionContainer" &&
+      child.expression.type === "JSXEmptyExpression"
+    )
+      return false;
+    if (
+      child.type === "JSXExpressionContainer" &&
+      child.expression.type === "Literal" &&
+      typeof child.expression.value === "string" &&
+      child.expression.value.trim() === ""
+    )
+      return false;
+    if (
+      child.type === "JSXExpressionContainer" &&
+      child.expression.type === "JSXFragment"
+    )
+      return true;
+    if (child.type === "JSXElement" || child.type === "JSXFragment")
+      return true;
+    // Ignore comments
+    return (
+      child.type !== "JSXExpressionContainer" ||
+      child.expression.type !== "JSXEmptyExpression"
+    );
+  });
+}
+
+function isFragmentElement(node) {
+  return (
+    node.openingElement &&
+    ((node.openingElement.name.type === "JSXMemberExpression" &&
+      node.openingElement.name.object.name === "React" &&
+      node.openingElement.name.property.name === "Fragment") ||
+      (node.openingElement.name.type === "JSXIdentifier" &&
+        node.openingElement.name.name === "Fragment"))
+  );
+}
+
+module.exports = {
+  getMeaningfulChildren,
+  isFragmentElement,
+};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-frontend-rules",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "Reusable ESLint plugin for frontend projects: enforces consistent naming, design, and code quality rules for React and TypeScript, including Typography components, color usage, file naming, export style, and more.",
   "main": "dist/index.js",
   "keywords": [


### PR DESCRIPTION
## Add `no-unnecessary-fragment` Rule

### Overview
This PR introduces a new rule, `no-unnecessary-fragment`, to the `eslint-frontend-rules` plugin. The rule helps keep your React code clean by warning when React fragments are used unnecessarily.

### What does the rule do?
- Warns if a fragment (`<>...</>`, `<React.Fragment>...</React.Fragment>`, or `<Fragment>...</Fragment>`) wraps only a single child or is not needed for grouping.
- Supports both short syntax and named fragments.
- Ignores comments and whitespace when determining if a fragment is unnecessary.
- Helps maintain readable and minimal JSX.

### Example
```jsx
// Warns:
return (
  <>
    <div />
  </>
);

return (
  <Fragment>
    <div />
  </Fragment>
);

return (
  <React.Fragment>
    <div />
  </React.Fragment>
);

// OK:
return (
  <>
    <div />
    <span />
  </>
);