### PR TITLE
feat: require js doc for root level functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,59 @@ return (
 );
 ```
 
+### 12. require-jsdoc-on-root-function
+
+**Warns if a root-level function (not a React component or hook) lacks a JSDoc comment.**
+
+- Only applies to root-level functions (not inside a component/class).
+- Skips React components (names starting with uppercase) and hooks (names starting with `use`).
+- Supports folder restriction via options (e.g., only in `utils/`).
+- Error: Root-level function "myFunction" should have a JSDoc comment.
+- Options:
+  - `folders`: Array of glob patterns to restrict rule to certain folders/files.
+
+**Example configuration:**
+
+```js
+rules: {
+  'eslint-frontend-rules/require-jsdoc-on-root-function': [
+    'warn',
+    { folders: ['src/utils/**'] }
+  ]
+}
+```
+
+**Example:**
+
+```js
+// Warns:
+function myUtil() {
+  /* ... */
+}
+
+const doSomething = () => {
+  /* ... */
+};
+
+// OK (has JSDoc):
+/**
+ * Adds two numbers.
+ */
+function add(a, b) {
+  return a + b;
+}
+
+// OK (component):
+function MyComponent() {
+  return <div />;
+}
+
+// OK (hook):
+function useCustomHook() {
+  /* ... */
+}
+```
+
 ## Example: Custom Rule Options
 
 ```json

--- a/lib/index.js
+++ b/lib/index.js
@@ -19,6 +19,9 @@ const plugin = {
     "no-inline-arrow-functions-in-jsx": require("./rules/react/no-inline-arrow-functions-in-jsx"),
     "no-nested-component": require("./rules/react/no-nested-component"),
     "no-unnecessary-fragment": require("./rules/react/no-unnecessary-fragment"),
+
+    //documentation
+    "require-jsdoc-on-root-function": require("./rules/documentation/require-jsdoc-on-root-function"),
   },
 };
 
@@ -40,6 +43,7 @@ plugin.configs = {
       "eslint-frontend-rules/enforce-alias-import-paths": "warn",
       "eslint-frontend-rules/no-nested-component": "error",
       "eslint-frontend-rules/no-unnecessary-fragment": "warn",
+      "eslint-frontend-rules/require-jsdoc-on-root-function": "warn",
     },
   },
 };

--- a/lib/rules/documentation/require-jsdoc-on-root-function.js
+++ b/lib/rules/documentation/require-jsdoc-on-root-function.js
@@ -1,0 +1,84 @@
+/**
+ * @fileoverview Warns if a root-level function lacks a JSDoc comment.
+ * Supports folder restriction via options.
+ */
+
+const micromatch = require("micromatch");
+const { hasJSDoc, isRootLevel } = require("../../utils/documentation");
+const { isComponentName, isHookName } = require("../../utils/react");
+
+module.exports = {
+  meta: {
+    type: "suggestion",
+    docs: {
+      description: "Require JSDoc comment for root-level functions",
+      category: "Documentation",
+      recommended: false,
+    },
+    schema: [
+      {
+        type: "object",
+        properties: {
+          folders: {
+            type: "array",
+            items: { type: "string" },
+            description:
+              "Only apply rule to files in these folders (micromatch patterns)",
+          },
+        },
+        additionalProperties: false,
+      },
+    ],
+    messages: {
+      missingJSDoc:
+        'Root-level function "{{name}}" should have a JSDoc comment.',
+    },
+  },
+  create(context) {
+    const options = context.options[0] || {};
+    const folders = options.folders || null;
+    const filename = context.getFilename();
+    if (
+      folders &&
+      !folders.some((pattern) => micromatch.isMatch(filename, pattern))
+    ) {
+      return {};
+    }
+    const sourceCode = context.getSourceCode();
+
+    function checkFunction(node) {
+      if (!isRootLevel(node)) return;
+      const name = node.id ? node.id.name : null;
+      if (isComponentName(name) || isHookName(name)) return; // skip components and hooks
+      if (hasJSDoc(node, sourceCode)) return;
+      context.report({
+        node,
+        messageId: "missingJSDoc",
+        data: { name: name || "(anonymous)" },
+      });
+    }
+    return {
+      FunctionDeclaration: checkFunction,
+      VariableDeclaration(node) {
+        if (!isRootLevel(node)) return;
+        for (const decl of node.declarations) {
+          const name = decl.id && decl.id.name;
+          if (
+            decl.init &&
+            (decl.init.type === "ArrowFunctionExpression" ||
+              decl.init.type === "FunctionExpression")
+          ) {
+            if (isComponentName(name) || isHookName(name)) continue; // skip components and hooks
+            if (!hasJSDoc(node, sourceCode)) {
+              context.report({
+                node: decl,
+                messageId: "missingJSDoc",
+                data: { name: name || "(anonymous)" },
+              });
+            }
+          }
+        }
+      },
+    };
+  },
+};

--- a/lib/rules/react/no-nested-component.js
+++ b/lib/rules/react/no-nested-component.js
@@ -10,6 +10,7 @@
  * Configuration:
  * - `ignore`: Array of glob patterns to ignore files.
  */
+const { isComponent } = require("../../utils/react");
 
 const rule = {
   meta: {
@@ -45,41 +46,7 @@ const rule = {
       const filename = context.getFilename();
       if (micromatch.isMatch(filename, ignorePatterns)) return {};
     }
-    // Helper: is a function/class a React component?
-    function isComponent(node) {
-      if (
-        node.type === "FunctionDeclaration" ||
-        node.type === "FunctionExpression" ||
-        node.type === "ArrowFunctionExpression"
-      ) {
-        // Heuristic: name starts with uppercase, or returns JSX
-        if (node.id && /^[A-Z]/.test(node.id.name)) return true;
-        if (
-          node.parent &&
-          node.parent.type === "VariableDeclarator" &&
-          /^[A-Z]/.test(node.parent.id.name)
-        )
-          return true;
-        // Returns JSX (JSXElement or JSXFragment)
-        if (node.body && node.body.type === "BlockStatement") {
-          return node.body.body.some(
-            (stmt) =>
-              stmt.type === "ReturnStatement" &&
-              stmt.argument &&
-              (stmt.argument.type === "JSXElement" ||
-                stmt.argument.type === "JSXFragment")
-          );
-        }
-      }
-      if (
-        node.type === "ClassDeclaration" &&
-        node.id &&
-        /^[A-Z]/.test(node.id.name)
-      ) {
-        return true;
-      }
-      return false;
-    }
+
     // Track component nesting
     let componentStack = [];
     return {

--- a/lib/rules/react/no-unnecessary-fragment.js
+++ b/lib/rules/react/no-unnecessary-fragment.js
@@ -9,7 +9,7 @@
 const {
   getMeaningfulChildren,
   isFragmentElement,
-} = require("../../utils/fragment-helpers");
+} = require("../../utils/react");
 
 const rule = {
   meta: {

--- a/lib/utils/documentation.js
+++ b/lib/utils/documentation.js
@@ -1,0 +1,14 @@
+function hasJSDoc(node, sourceCode) {
+  const jsdoc = sourceCode
+    .getCommentsBefore(node)
+    .find(
+      (comment) => comment.type === "Block" && comment.value.startsWith("*")
+    );
+  return Boolean(jsdoc);
+}
+
+function isRootLevel(node) {
+  return node.parent && node.parent.type === "Program";
+}
+
+module.exports = { hasJSDoc, isRootLevel };

--- a/lib/utils/react.js
+++ b/lib/utils/react.js
@@ -43,7 +43,53 @@ function isFragmentElement(node) {
   );
 }
 
+// Helper: is a function/class a React component?
+function isComponent(node) {
+  if (
+    node.type === "FunctionDeclaration" ||
+    node.type === "FunctionExpression" ||
+    node.type === "ArrowFunctionExpression"
+  ) {
+    // Heuristic: name starts with uppercase, or returns JSX
+    if (node.id && /^[A-Z]/.test(node.id.name)) return true;
+    if (
+      node.parent &&
+      node.parent.type === "VariableDeclarator" &&
+      /^[A-Z]/.test(node.parent.id.name)
+    )
+      return true;
+    // Returns JSX (JSXElement or JSXFragment)
+    if (node.body && node.body.type === "BlockStatement") {
+      return node.body.body.some(
+        (stmt) =>
+          stmt.type === "ReturnStatement" &&
+          stmt.argument &&
+          (stmt.argument.type === "JSXElement" ||
+            stmt.argument.type === "JSXFragment")
+      );
+    }
+  }
+  if (
+    node.type === "ClassDeclaration" &&
+    node.id &&
+    /^[A-Z]/.test(node.id.name)
+  ) {
+    return true;
+  }
+  return false;
+}
+
+function isComponentName(name) {
+  return name && /^[A-Z]/.test(name);
+}
+function isHookName(name) {
+  return name && /^use[A-Z0-9]/.test(name);
+}
+
 module.exports = {
   getMeaningfulChildren,
   isFragmentElement,
+  isComponent,
+  isComponentName,
+  isHookName,
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-frontend-rules",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "description": "Reusable ESLint plugin for frontend projects: enforces consistent naming, design, and code quality rules for React and TypeScript, including Typography components, color usage, file naming, export style, and more.",
   "main": "dist/index.js",
   "keywords": [


### PR DESCRIPTION
## PR: Add `require-jsdoc-on-root-function` Rule, Documentation, and Version Bump

### ✨ New Rule: `require-jsdoc-on-root-function`
- Adds a rule to warn if a root-level function (not a React component or hook) lacks a JSDoc comment.
- Skips React components (names starting with uppercase) and hooks (names starting with `use`).
- Supports folder restriction via the `folders` option (e.g., only in `utils/`).
- Helps enforce documentation standards for utility and helper functions.

### 📝 Documentation Update
- Updated `README.md` to document the new rule:
  - Added rule description, options, and usage examples.
  - Included example configuration and code samples.

### 🔖 Version Bump
- Updated `package.json` version to `1.0.9` to reflect the new rule and documentation improvements.

---
This PR improves code quality and documentation consistency for frontend projects using this ESLint plugin.