### PR TITLE
feat: add no-unnecessary-curly-in-props rule to warn against unnecessary curly braces in JSX props

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,7 +288,9 @@ function useCustom() {
   // ...
 }
 
-const useSomething = () => { /* ... */ };
+const useSomething = () => {
+  /* ... */
+};
 
 // OK (has JSDoc):
 /**
@@ -297,6 +299,25 @@ const useSomething = () => { /* ... */ };
 function useCustom() {
   // ...
 }
+```
+
+### 15. no-unnecessary-curly-in-props
+
+**Warns if JSX props use unnecessary curly braces for string literals.**
+
+- Example: `<Component name={'xyz'} />` (should be `<Component name="xyz" />`)
+- Auto-fixable: will convert `{'xyz'}` to `"xyz"` in props.
+- No options.
+
+**Example:**
+
+```jsx
+// Warns and auto-fixes:
+<Component name={'xyz'} />
+
+// OK:
+<Component name="xyz" />
+<Component name={someVar} />
 ```
 
 ## Example: Custom Rule Options

--- a/lib/index.js
+++ b/lib/index.js
@@ -19,6 +19,7 @@ const plugin = {
     "no-inline-arrow-functions-in-jsx": require("./rules/react/no-inline-arrow-functions-in-jsx"),
     "no-nested-component": require("./rules/react/no-nested-component"),
     "no-unnecessary-fragment": require("./rules/react/no-unnecessary-fragment"),
+    "no-unnecessary-curly-in-props": require("./rules/react/no-unnecessary-curly-in-props"),
 
     //documentation
     "require-jsdoc-on-root-function": require("./rules/documentation/require-jsdoc-on-root-function"),
@@ -45,6 +46,7 @@ plugin.configs = {
       "eslint-frontend-rules/enforce-alias-import-paths": "warn",
       "eslint-frontend-rules/no-nested-component": "error",
       "eslint-frontend-rules/no-unnecessary-fragment": "warn",
+      "eslint-frontend-rules/no-unnecessary-curly-in-props": "warn",
       "eslint-frontend-rules/require-jsdoc-on-root-function": "warn",
       "eslint-frontend-rules/require-jsdoc-on-component": "warn",
       "eslint-frontend-rules/require-jsdoc-on-hook": "warn",

--- a/lib/rules/react/no-unnecessary-curly-in-props.js
+++ b/lib/rules/react/no-unnecessary-curly-in-props.js
@@ -1,0 +1,47 @@
+/**
+ * @fileoverview Warns if JSX props use unnecessary curly braces for string literals.
+ * Example: <Component name={'xyz'} /> (should be <Component name="xyz" />)
+ */
+
+module.exports = {
+  meta: {
+    type: "suggestion",
+    docs: {
+      description:
+        "Disallow unnecessary curly braces for string literal props in JSX.",
+      category: "Stylistic Issues",
+      recommended: false,
+    },
+    fixable: "code",
+    schema: [],
+    messages: {
+      unnecessaryCurly:
+        "Unnecessary curly braces for string literal prop '{{prop}}'. Use plain string instead.",
+    },
+  },
+  create(context) {
+    return {
+      JSXAttribute(node) {
+        if (
+          node.value &&
+          node.value.type === "JSXExpressionContainer" &&
+          node.value.expression.type === "Literal" &&
+          typeof node.value.expression.value === "string"
+        ) {
+          context.report({
+            node: node.value,
+            messageId: "unnecessaryCurly",
+            data: { prop: node.name.name },
+            fix(fixer) {
+              // Replace {'xyz'} with "xyz"
+              const raw =
+                node.value.expression.raw ||
+                JSON.stringify(node.value.expression.value);
+              return fixer.replaceText(node.value, raw);
+            },
+          });
+        }
+      },
+    };
+  },
+};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-frontend-rules",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "description": "Reusable ESLint plugin for frontend projects: enforces consistent naming, design, and code quality rules for React and TypeScript, including Typography components, color usage, file naming, export style, and more.",
   "main": "dist/index.js",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-frontend-rules",
-  "version": "1.0.11",
+  "version": "1.1.0",
   "description": "Reusable ESLint plugin for frontend projects: enforces consistent naming, design, and code quality rules for React and TypeScript, including Typography components, color usage, file naming, export style, and more.",
   "main": "dist/index.js",
   "keywords": [


### PR DESCRIPTION
## PR: Add Rule to Disallow Unnecessary Curly Braces in JSX Props

### ✨ New Rule: `no-unnecessary-curly-in-props`
- **Purpose:** Warns when JSX props use unnecessary curly braces for string literals.
- **Example:**  
  - Warns: `<Component name={'xyz'} />`  
  - Preferred: `<Component name="xyz" />`
- **Auto-fixable:** The rule will automatically convert `{'xyz'}` to `"xyz"` in props.
- **Category:** Stylistic Issues
- **Default:** Added as a warning in the recommended config.

### 📖 Documentation
- Added rule documentation to the README, including description, usage, and examples.

### 🆙 Version Bump
- Updated `package.json` version to `1.1.0` to reflect the new rule addition.

---

This PR improves code style consistency in JSX by enforcing the use of plain string props where possible and reducing unnecessary