### PR TITLE
feat: add enforce-classname-utility rule to encourage using utility functions for className in JSX

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,6 +318,41 @@ function useCustom() {
 // OK:
 <Component name="xyz" />
 <Component name={someVar} />
+<Component name="" /> // allowed by default
+```
+
+### 16. enforce-classname-utility
+
+**Warns if the `className` prop in JSX is set to a template string (e.g., `` className={`foo ${bar}`} ``) instead of using a function or library (like `cn`).**
+
+- Example: `<Component className={\`foo ${bar}\`} />`(should use`cn` or a similar utility)
+- Allows plain string literals (e.g., `className="foo bar"`) and empty string by default.
+- Options:
+  - `allow`: Array of allowed string literal values for className (default: `[""]`).
+
+**Example configuration:**
+
+```js
+rules: {
+  'eslint-frontend-rules/enforce-classname-utility': [
+    'warn',
+    { allow: [""] }
+  ]
+}
+```
+
+**Example:**
+
+```jsx
+// Warns:
+<Component className={`foo ${bar}`} />
+<Component className={`btn ${isActive ? 'active' : ''}`} />
+
+// OK:
+<Component className={cn('foo', { active })} />
+<Component className={someVar} />
+<Component className="foo bar" />
+<Component className="" /> // allowed by default
 ```
 
 ## Example: Custom Rule Options

--- a/lib/index.js
+++ b/lib/index.js
@@ -20,6 +20,7 @@ const plugin = {
     "no-nested-component": require("./rules/react/no-nested-component"),
     "no-unnecessary-fragment": require("./rules/react/no-unnecessary-fragment"),
     "no-unnecessary-curly-in-props": require("./rules/react/no-unnecessary-curly-in-props"),
+    "enforce-classname-utility": require("./rules/react/enforce-classname-utility"),
 
     //documentation
     "require-jsdoc-on-root-function": require("./rules/documentation/require-jsdoc-on-root-function"),
@@ -47,6 +48,7 @@ plugin.configs = {
       "eslint-frontend-rules/no-nested-component": "error",
       "eslint-frontend-rules/no-unnecessary-fragment": "warn",
       "eslint-frontend-rules/no-unnecessary-curly-in-props": "warn",
+      "eslint-frontend-rules/enforce-classname-utility": "warn",
       "eslint-frontend-rules/require-jsdoc-on-root-function": "warn",
       "eslint-frontend-rules/require-jsdoc-on-component": "warn",
       "eslint-frontend-rules/require-jsdoc-on-hook": "warn",

--- a/lib/rules/react/enforce-classname-utility.js
+++ b/lib/rules/react/enforce-classname-utility.js
@@ -1,0 +1,54 @@
+/**
+ * @fileoverview Warns if className prop in JSX is set to a template string (e.g., className={`foo ${bar}`}) instead of using a function/library like cn.
+ * Example: <Component className={`foo ${bar}`} /> (should use cn or a similar utility)
+ */
+
+module.exports = {
+  meta: {
+    type: "suggestion",
+    docs: {
+      description:
+        "Encourage use of a function/library (e.g., cn) for className instead of string literals.",
+      category: "Best Practices",
+      recommended: false,
+    },
+    schema: [
+      {
+        type: "object",
+        properties: {
+          allow: {
+            type: "array",
+            items: { type: "string" },
+            description:
+              "Allow these string literal values for className (e.g., empty string)",
+          },
+        },
+        additionalProperties: false,
+      },
+    ],
+    messages: {
+      useCn:
+        "Use a function or library (e.g., cn) to handle className instead of a string literal.",
+    },
+  },
+  create(context) {
+    const options = context.options[0] || {};
+    const allow = options.allow || [""];
+    return {
+      JSXAttribute(node) {
+        if (
+          node.name &&
+          node.name.name === "className" &&
+          node.value &&
+          node.value.type === "JSXExpressionContainer" &&
+          node.value.expression.type === "TemplateLiteral"
+        ) {
+          context.report({
+            node: node.value,
+            messageId: "useCn",
+          });
+        }
+      },
+    };
+  },
+};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-frontend-rules",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Reusable ESLint plugin for frontend projects: enforces consistent naming, design, and code quality rules for React and TypeScript, including Typography components, color usage, file naming, export style, and more.",
   "main": "dist/index.js",
   "keywords": [


### PR DESCRIPTION

## PR: Refine `enforce-classname-utility` Rule to Target Only Template Strings

### 🛠️ New Rule
- **Rule Added:** The `enforce-classname-utility` rule now only warns when the `className` prop in JSX is set using a template string (e.g., ``className={`foo ${bar}`}``), rather than warning for all string literals.
- **Rationale:** Template strings are often used for conditional classes, but using a function or library like `cn` is preferred for readability and maintainability. Plain string literals (e.g., `className="foo bar"`) are now allowed.
- **Documentation:** Updated the README to clarify the rule’s intent and provide correct examples for both warnings and allowed usage.

### 📖 Example

```jsx
// Warns:
<Component className={`foo ${bar}`} />
<Component className={`btn ${isActive ? 'active' : ''}`} />

// OK:
<Component className={cn('foo', { active })} />
<Component className={someVar} />
<Component className="foo bar" />
<Component className="" /> // allowed by default