### PR TITLE
feat: add rule to disallow empty css classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -353,6 +353,32 @@ rules: {
 <Component className={someVar} />
 <Component className="foo bar" />
 <Component className="" /> // allowed by default
+
+```
+### 17. no-empty-classname
+
+**Disallows empty or whitespace-only `className` attributes in JSX.**
+
+- Flags cases where `className` is set but contains no usable value.
+- Helps keep code clean by avoiding unnecessary `className=""`, `className="   "`, or `className={""}`.
+- Works with string literals, expression containers, and template literals.
+- No options.
+
+**Error:** Empty className string found. Remove it or add valid classes.
+
+**Example:**
+
+```jsx
+// ❌ Warns:
+<div className="" />
+<div className="   " />
+<div className={""} />
+<div className={`   `} />
+
+// ✅ OK:
+<div className="btn primary" />
+<div className={isActive ? "btn-active" : "btn"} />
+<div />
 ```
 
 ## Example: Custom Rule Options

--- a/lib/index.js
+++ b/lib/index.js
@@ -21,7 +21,7 @@ const plugin = {
     "no-unnecessary-fragment": require("./rules/react/no-unnecessary-fragment"),
     "no-unnecessary-curly-in-props": require("./rules/react/no-unnecessary-curly-in-props"),
     "enforce-classname-utility": require("./rules/react/enforce-classname-utility"),
-    "no-empty-tailwind-class": require("./rules/react/no-empty-tailwind-class"),
+    "enforce-no-empty-classname-utility": require("./rules/react/enforce-no-empty-classname-utility"),
 
     //documentation
     "require-jsdoc-on-root-function": require("./rules/documentation/require-jsdoc-on-root-function"),

--- a/lib/index.js
+++ b/lib/index.js
@@ -21,6 +21,7 @@ const plugin = {
     "no-unnecessary-fragment": require("./rules/react/no-unnecessary-fragment"),
     "no-unnecessary-curly-in-props": require("./rules/react/no-unnecessary-curly-in-props"),
     "enforce-classname-utility": require("./rules/react/enforce-classname-utility"),
+    "no-empty-tailwind-class": require("./rules/react/no-empty-tailwind-class"),
 
     //documentation
     "require-jsdoc-on-root-function": require("./rules/documentation/require-jsdoc-on-root-function"),
@@ -49,6 +50,7 @@ plugin.configs = {
       "eslint-frontend-rules/no-unnecessary-fragment": "warn",
       "eslint-frontend-rules/no-unnecessary-curly-in-props": "warn",
       "eslint-frontend-rules/enforce-classname-utility": "warn",
+      "eslint-frontend-rules/no-empty-tailwind-class": "warn",
       "eslint-frontend-rules/require-jsdoc-on-root-function": "warn",
       "eslint-frontend-rules/require-jsdoc-on-component": "warn",
       "eslint-frontend-rules/require-jsdoc-on-hook": "warn",

--- a/lib/rules/react/enforce-no-empty-classname-utility.js
+++ b/lib/rules/react/enforce-no-empty-classname-utility.js
@@ -8,12 +8,12 @@ module.exports = {
   meta: {
     type: "suggestion",
     docs: {
-      description: "Disallow empty Tailwind CSS class strings",
+      description: "Disallow empty className strings",
       category: "Best Practices",
     },
     messages: {
-      emptyTailwindClass:
-        "Empty Tailwind CSS class string found. Remove it or add classes.",
+      emptyClassName:
+        "Empty className string found. Remove it or add valid classes.",
     },
   },
   create: function (context) {
@@ -22,15 +22,15 @@ module.exports = {
         if (node.name.name === "className") {
           const value = node.value;
 
-          if (value.type === "Literal") {
+          if (value?.type === "Literal") {
             // className="   " or className=""
             if (typeof value.value === "string" && value.value.trim() === "") {
               context.report({
                 node: value,
-                messageId: "emptyTailwindClass",
+                messageId: "emptyClassName",
               });
             }
-          } else if (value.type === "JSXExpressionContainer") {
+          } else if (value?.type === "JSXExpressionContainer") {
             const expression = value.expression;
 
             // className={""} or className={"   "}
@@ -41,7 +41,7 @@ module.exports = {
             ) {
               context.report({
                 node: expression,
-                messageId: "emptyTailwindClass",
+                messageId: "emptyClassName",
               });
             }
             // className={``} or className={`   `}
@@ -52,7 +52,7 @@ module.exports = {
             ) {
               context.report({
                 node: expression,
-                messageId: "emptyTailwindClass",
+                messageId: "emptyClassName",
               });
             }
           }

--- a/lib/rules/react/no-empty-tailwind-class.js
+++ b/lib/rules/react/no-empty-tailwind-class.js
@@ -1,0 +1,63 @@
+/**
+ * @fileoverview Warns if className has accidental empty strings or just whitespace (className=" ").
+ */
+
+"use strict";
+
+module.exports = {
+  meta: {
+    type: "suggestion",
+    docs: {
+      description: "Disallow empty Tailwind CSS class strings",
+      category: "Best Practices",
+    },
+    messages: {
+      emptyTailwindClass:
+        "Empty Tailwind CSS class string found. Remove it or add classes.",
+    },
+  },
+  create: function (context) {
+    return {
+      JSXAttribute(node) {
+        if (node.name.name === "className") {
+          const value = node.value;
+
+          if (value.type === "Literal") {
+            // className="   " or className=""
+            if (typeof value.value === "string" && value.value.trim() === "") {
+              context.report({
+                node: value,
+                messageId: "emptyTailwindClass",
+              });
+            }
+          } else if (value.type === "JSXExpressionContainer") {
+            const expression = value.expression;
+
+            // className={""} or className={"   "}
+            if (
+              expression.type === "Literal" &&
+              typeof expression.value === "string" &&
+              expression.value.trim() === ""
+            ) {
+              context.report({
+                node: expression,
+                messageId: "emptyTailwindClass",
+              });
+            }
+            // className={``} or className={`   `}
+            else if (
+              expression.type === "TemplateLiteral" &&
+              expression.quasis.length === 1 &&
+              expression.quasis[0].value.raw.trim() === ""
+            ) {
+              context.report({
+                node: expression,
+                messageId: "emptyTailwindClass",
+              });
+            }
+          }
+        }
+      },
+    };
+  },
+};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-frontend-rules",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Reusable ESLint plugin for frontend projects: enforces consistent naming, design, and code quality rules for React and TypeScript, including Typography components, color usage, file naming, export style, and more.",
   "main": "dist/index.js",
   "keywords": [


### PR DESCRIPTION
### Description

This PR introduces a rule to **prevent the usage of empty CSS class attributes**. Empty class attributes add unnecessary noise in the codebase and reduce readability.

### Changes

* Added lint rule to disallow empty `className` attributes.
* Ensures cleaner, more consistent code.

### Why

* Improves code quality by avoiding redundant attributes.
* Helps maintain consistent usage across the project.