### PR TITLE
Feat/upgrade version

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -6,6 +6,7 @@ const plugin = {
     // Naming
     "top-level-const-snake": require("./rules/naming/top-level-const-snake"),
     "enforce-interface-type-naming": require("./rules/naming/enforce-interface-type-naming"),
+    "enforce-boolean-prop-naming": require("./rules/naming/enforce-boolean-prop-naming"),
     // Accessibility
     "no-focusable-non-interactive-elements": require("./rules/accessibility/no-focusable-non-interactive-elements"),
     // File Structure
@@ -15,6 +16,7 @@ const plugin = {
     "enforce-alias-import-paths": require("./rules/import-export/enforce-alias-import-paths"),
     // TypeScript
     "interface-type-required-first": require("./rules/typescript/interface-type-required-first"),
+    "enforce-enum-member-naming": require("./rules/typescript/enforce-enum-member-naming"),
     // React
     "no-inline-arrow-functions-in-jsx": require("./rules/react/no-inline-arrow-functions-in-jsx"),
     "no-nested-component": require("./rules/react/no-nested-component"),
@@ -22,11 +24,15 @@ const plugin = {
     "no-unnecessary-curly-in-props": require("./rules/react/no-unnecessary-curly-in-props"),
     "enforce-classname-utility": require("./rules/react/enforce-classname-utility"),
     "enforce-no-empty-classname-utility": require("./rules/react/enforce-no-empty-classname-utility"),
+    "enforce-use-state-naming": require("./rules/react/enforce-use-state-naming"),
+    "enforce-event-handler-naming": require("./rules/react/enforce-event-handler-naming"),
 
-    //documentation
+    // Documentation
     "require-jsdoc-on-root-function": require("./rules/documentation/require-jsdoc-on-root-function"),
     "require-jsdoc-on-component": require("./rules/documentation/require-jsdoc-on-component"),
     "require-jsdoc-on-hook": require("./rules/documentation/require-jsdoc-on-hook"),
+    // Testing
+    "enforce-testid-naming": require("./rules/testing/enforce-testid-naming"),
   },
 };
 
@@ -50,7 +56,12 @@ plugin.configs = {
       "eslint-frontend-rules/no-unnecessary-fragment": "warn",
       "eslint-frontend-rules/no-unnecessary-curly-in-props": "warn",
       "eslint-frontend-rules/enforce-classname-utility": "warn",
-      "eslint-frontend-rules/no-empty-tailwind-class": "warn",
+      "eslint-frontend-rules/enforce-no-empty-classname-utility": "warn",
+      "eslint-frontend-rules/enforce-use-state-naming": "warn",
+      "eslint-frontend-rules/enforce-event-handler-naming": "warn",
+      "eslint-frontend-rules/enforce-boolean-prop-naming": "warn",
+      "eslint-frontend-rules/enforce-enum-member-naming": "warn",
+      "eslint-frontend-rules/enforce-testid-naming": "warn",
       "eslint-frontend-rules/require-jsdoc-on-root-function": "warn",
       "eslint-frontend-rules/require-jsdoc-on-component": "warn",
       "eslint-frontend-rules/require-jsdoc-on-hook": "warn",

--- a/lib/rules/accessibility/no-focusable-non-interactive-elements.js
+++ b/lib/rules/accessibility/no-focusable-non-interactive-elements.js
@@ -35,6 +35,7 @@ const rule = {
       nonInteractive:
         'Non-interactive element <{{tag}}> with onClick detected. Consider using <button> or adding role="button" and onKeyDown for accessibility.',
     },
+    fixable: "code",
     schema: [
       {
         type: "object",
@@ -49,7 +50,7 @@ const rule = {
     ],
   },
   create(context) {
-    const filename = context.getFilename();
+    const filename = context.filename;
     const options = context.options[0] || {};
     const ignorePatterns = options.ignore || [];
     if (ignorePatterns.length) {
@@ -67,7 +68,7 @@ const rule = {
           (attr) =>
             attr.type === "JSXAttribute" &&
             attr.name &&
-            attr.name.name === "onClick"
+            attr.name.name === "onClick",
         );
         if (!hasOnClick) return;
         const hasRoleButton = node.attributes.some(
@@ -77,19 +78,57 @@ const rule = {
             attr.name.name === "role" &&
             attr.value &&
             attr.value.type === "Literal" &&
-            attr.value.value === "button"
+            attr.value.value === "button",
         );
         const hasOnKeyDown = node.attributes.some(
           (attr) =>
             attr.type === "JSXAttribute" &&
             attr.name &&
-            attr.name.name === "onKeyDown"
+            attr.name.name === "onKeyDown",
         );
         if (!hasRoleButton && !hasOnKeyDown) {
           context.report({
             node,
             messageId: "nonInteractive",
             data: { tag },
+            fix(fixer) {
+              const fixes = [];
+              const lastAttr = node.attributes[node.attributes.length - 1];
+              const insertPos = lastAttr
+                ? lastAttr.range[1]
+                : node.name.range[1];
+              if (!hasRoleButton) {
+                fixes.push(
+                  fixer.insertTextAfterRange(
+                    [insertPos, insertPos],
+                    ' role="button" tabIndex={0}',
+                  ),
+                );
+              }
+              // Add onKeyDown handler that triggers onClick on Enter/Space
+              const onClickAttr = node.attributes.find(
+                (attr) =>
+                  attr.type === "JSXAttribute" &&
+                  attr.name &&
+                  attr.name.name === "onClick",
+              );
+              if (onClickAttr && onClickAttr.value) {
+                const sourceCode = context.sourceCode;
+                const onClickValue = sourceCode.getText(onClickAttr.value);
+                const insertAfterPos = fixes.length > 0 ? insertPos : insertPos;
+                const keyDownInsert =
+                  fixes.length > 0
+                    ? ` onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") ${onClickValue.startsWith("{") ? onClickValue.slice(1, -1) : onClickValue}(e); }}`
+                    : ` onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") ${onClickValue.startsWith("{") ? onClickValue.slice(1, -1) : onClickValue}(e); }}`;
+                fixes.push(
+                  fixer.insertTextAfterRange(
+                    [insertPos, insertPos],
+                    keyDownInsert,
+                  ),
+                );
+              }
+              return fixes;
+            },
           });
         }
       },

--- a/lib/rules/design/enforce-typography-components.js
+++ b/lib/rules/design/enforce-typography-components.js
@@ -40,7 +40,7 @@ module.exports = {
     ],
   },
   create(context) {
-    const filename = context.getFilename();
+    const filename = context.filename;
     const options = context.options[0] || {};
     const ignorePatterns = options.ignore || [];
     // Always ignore typography.tsx

--- a/lib/rules/design/no-direct-colors.js
+++ b/lib/rules/design/no-direct-colors.js
@@ -30,7 +30,7 @@ module.exports = {
     ],
   },
   create(context) {
-    const filename = context.getFilename();
+    const filename = context.filename;
     const options = context.options[0] || {};
     const ignorePatterns = options.ignore || [];
     if (ignorePatterns.length && micromatch.isMatch(filename, ignorePatterns))
@@ -67,7 +67,7 @@ module.exports = {
                   } else if (prop.value.type === "TemplateLiteral") {
                     checkValue(
                       prop.value,
-                      prop.value.quasis.map((q) => q.value.cooked).join("")
+                      prop.value.quasis.map((q) => q.value.cooked).join(""),
                     );
                   }
                 }
@@ -82,7 +82,7 @@ module.exports = {
                   node.value,
                   node.value.expression.quasis
                     .map((q) => q.value.cooked)
-                    .join("")
+                    .join(""),
                 );
               }
             }

--- a/lib/rules/documentation/require-jsdoc-on-component.js
+++ b/lib/rules/documentation/require-jsdoc-on-component.js
@@ -2,12 +2,7 @@
  * @fileoverview Warns if a root-level React component lacks a JSDoc comment.
  * Supports folder restriction via options.
  */
-const micromatch = require("micromatch");
-const {
-  hasJSDoc,
-  isRootLevel,
-  createJsdocRule,
-} = require("../../utils/documentation");
+const { createJsdocRule } = require("../../utils/documentation");
 const { isComponentName } = require("../../utils/react");
 
 module.exports = createJsdocRule({

--- a/lib/rules/documentation/require-jsdoc-on-hook.js
+++ b/lib/rules/documentation/require-jsdoc-on-hook.js
@@ -2,12 +2,7 @@
  * @fileoverview Warns if a root-level React hook lacks a JSDoc comment.
  * Supports folder restriction via options.
  */
-const micromatch = require("micromatch");
-const {
-  hasJSDoc,
-  isRootLevel,
-  createJsdocRule,
-} = require("../../utils/documentation");
+const { createJsdocRule } = require("../../utils/documentation");
 const { isHookName } = require("../../utils/react");
 
 module.exports = createJsdocRule({

--- a/lib/rules/file-structure/enforce-kebab-case-filenames.js
+++ b/lib/rules/file-structure/enforce-kebab-case-filenames.js
@@ -40,7 +40,7 @@ const rule = {
     ],
   },
   create(context) {
-    const filename = context.getFilename();
+    const filename = context.filename;
     const options = context.options[0] || {};
     const ignorePatterns = options.ignore || [];
     const extensions = options.extensions || [".js", ".ts", ".jsx", ".tsx"];

--- a/lib/rules/import-export/enforce-alias-import-paths.js
+++ b/lib/rules/import-export/enforce-alias-import-paths.js
@@ -56,7 +56,7 @@ const rule = {
     ],
   },
   create(context) {
-    const filename = context.getFilename();
+    const filename = context.filename;
     const options = context.options[0] || {};
     const aliases = options.aliases || DEFAULT_ALIASES;
     const ignorePatterns = options.ignore || [];

--- a/lib/rules/import-export/no-default-export.js
+++ b/lib/rules/import-export/no-default-export.js
@@ -7,6 +7,7 @@ const rule = {
       description: "Disallow default exports; enforce named exports only.",
       category: "Best Practices",
     },
+    fixable: "code",
     messages: {
       noDefaultExport:
         "Default export is not allowed. Use named exports instead.",
@@ -25,7 +26,7 @@ const rule = {
     ],
   },
   create(context) {
-    const filename = context.getFilename();
+    const filename = context.filename;
     const options = context.options[0] || {};
     const ignorePatterns = options.ignore || [];
     if (ignorePatterns.length) {
@@ -34,9 +35,36 @@ const rule = {
     }
     return {
       ExportDefaultDeclaration(node) {
+        const declaration = node.declaration;
         context.report({
           node,
           messageId: "noDefaultExport",
+          fix(fixer) {
+            // export default function Foo() {} → export function Foo() {}
+            if (
+              (declaration.type === "FunctionDeclaration" ||
+                declaration.type === "ClassDeclaration") &&
+              declaration.id
+            ) {
+              const sourceCode = context.sourceCode;
+              const defaultToken = sourceCode.getFirstToken(node, {
+                skip: 0,
+              });
+              const nextToken = sourceCode.getTokenAfter(defaultToken);
+              // Remove "default " between "export" and the declaration keyword
+              if (
+                defaultToken.value === "export" &&
+                nextToken.value === "default"
+              ) {
+                const afterDefault = sourceCode.getTokenAfter(nextToken);
+                return fixer.removeRange([
+                  nextToken.range[0],
+                  afterDefault.range[0],
+                ]);
+              }
+            }
+            return null;
+          },
         });
       },
     };

--- a/lib/rules/naming/enforce-boolean-prop-naming.js
+++ b/lib/rules/naming/enforce-boolean-prop-naming.js
@@ -1,0 +1,107 @@
+/**
+ * @fileoverview Enforce that boolean props in TypeScript interfaces/types follow
+ * naming conventions (is*, has*, should*, can*, will*, did*).
+ */
+const micromatch = require("micromatch");
+
+const BOOLEAN_PREFIX_REGEX = /^(is|has|should|can|will|did)[A-Z]/;
+
+module.exports = {
+  meta: {
+    type: "suggestion",
+    docs: {
+      description:
+        "Enforce boolean prop names to start with is/has/should/can/will/did.",
+      category: "Best Practices",
+    },
+    messages: {
+      booleanPropNaming:
+        'Boolean prop "{{name}}" should start with is, has, should, can, will, or did (e.g., "is{{capitalized}}").',
+    },
+    fixable: "code",
+    schema: [
+      {
+        type: "object",
+        properties: {
+          ignore: {
+            type: "array",
+            items: { type: "string" },
+          },
+          prefixes: {
+            type: "array",
+            items: { type: "string" },
+            description: "Allowed prefixes for boolean props.",
+          },
+        },
+        additionalProperties: false,
+      },
+    ],
+  },
+  create(context) {
+    const filename = context.filename;
+    if (!filename.endsWith(".ts") && !filename.endsWith(".tsx")) return {};
+    const options = context.options[0] || {};
+    const ignorePatterns = options.ignore || [];
+    if (ignorePatterns.length && micromatch.isMatch(filename, ignorePatterns))
+      return {};
+    const prefixes = options.prefixes || [
+      "is",
+      "has",
+      "should",
+      "can",
+      "will",
+      "did",
+    ];
+    const prefixRegex = new RegExp(`^(${prefixes.join("|")})[A-Z]`);
+
+    function checkMember(member) {
+      if (member.type !== "TSPropertySignature") return;
+      if (!member.key || !member.key.name) return;
+      // Check if the type annotation is boolean
+      const typeAnnotation =
+        member.typeAnnotation && member.typeAnnotation.typeAnnotation;
+      if (!typeAnnotation) return;
+      const isBooleanType =
+        typeAnnotation.type === "TSBooleanKeyword" ||
+        (typeAnnotation.type === "TSUnionType" &&
+          typeAnnotation.types.every(
+            (t) =>
+              t.type === "TSBooleanKeyword" ||
+              (t.type === "TSLiteralType" &&
+                typeof t.literal.value === "boolean") ||
+              t.type === "TSUndefinedKeyword",
+          ));
+      if (!isBooleanType) return;
+      const name = member.key.name;
+      if (!prefixRegex.test(name)) {
+        const capitalized = name.charAt(0).toUpperCase() + name.slice(1);
+        context.report({
+          node: member.key,
+          messageId: "booleanPropNaming",
+          data: { name, capitalized },
+          fix(fixer) {
+            const newName = "is" + capitalized;
+            return fixer.replaceText(member.key, newName);
+          },
+        });
+      }
+    }
+
+    return {
+      TSInterfaceDeclaration(node) {
+        const members =
+          (node.body && node.body.body) || node.body || node.members || [];
+        members.forEach(checkMember);
+      },
+      TSTypeAliasDeclaration(node) {
+        if (
+          node.typeAnnotation &&
+          node.typeAnnotation.type === "TSTypeLiteral"
+        ) {
+          const members = node.typeAnnotation.members || [];
+          members.forEach(checkMember);
+        }
+      },
+    };
+  },
+};

--- a/lib/rules/naming/enforce-interface-type-naming.js
+++ b/lib/rules/naming/enforce-interface-type-naming.js
@@ -13,6 +13,7 @@ const rule = {
         "Enforce 'I' prefix or 'Props' suffix for interfaces, and 'T' prefix or 'Props' suffix for types in TypeScript files.",
       category: "Best Practices",
     },
+    fixable: "code",
     messages: {
       badInterfaceName:
         "Interface '{{name}}' should start with 'I' or end with 'Props'.",
@@ -32,7 +33,7 @@ const rule = {
     ],
   },
   create(context) {
-    const filename = context.getFilename();
+    const filename = context.filename;
     if (!filename.endsWith(".ts") && !filename.endsWith(".tsx")) return {};
     const options = context.options[0] || {};
     const ignorePatterns = options.ignore || [];
@@ -48,6 +49,11 @@ const rule = {
             node: node.id,
             messageId: "badInterfaceName",
             data: { name },
+            fix(fixer) {
+              const newName =
+                "I" + name.charAt(0).toUpperCase() + name.slice(1);
+              return fixer.replaceText(node.id, newName);
+            },
           });
         }
       },
@@ -58,6 +64,11 @@ const rule = {
             node: node.id,
             messageId: "badTypeName",
             data: { name },
+            fix(fixer) {
+              const newName =
+                "T" + name.charAt(0).toUpperCase() + name.slice(1);
+              return fixer.replaceText(node.id, newName);
+            },
           });
         }
       },

--- a/lib/rules/naming/top-level-const-snake.js
+++ b/lib/rules/naming/top-level-const-snake.js
@@ -6,6 +6,14 @@ function isAllCapsSnake(name) {
   return /^[A-Z][A-Z0-9_]*$/.test(name);
 }
 
+function toUpperSnake(name) {
+  // Convert camelCase/PascalCase to UPPER_SNAKE_CASE
+  return name
+    .replace(/([a-z0-9])([A-Z])/g, "$1_$2")
+    .replace(/([A-Z]+)([A-Z][a-z])/g, "$1_$2")
+    .toUpperCase();
+}
+
 const topLevelConstSnakeCase = {
   meta: {
     type: "suggestion",
@@ -13,6 +21,7 @@ const topLevelConstSnakeCase = {
       description: "Require top-level consts to be ALL_CAPS (snake case)",
       category: "Best Practices",
     },
+    fixable: "code",
     messages: {
       topLevelConstCaps:
         'Top-level const "{{name}}" should be ALL_CAPS (snake case).',
@@ -21,7 +30,7 @@ const topLevelConstSnakeCase = {
   },
   create(context) {
     // Only run this rule for .tsx files
-    const filename = context.getFilename();
+    const filename = context.filename;
     const options = context.options[0] || {};
     const ignorePatterns = options.ignore || [];
     if (!filename.endsWith(".tsx")) {
@@ -56,6 +65,28 @@ const topLevelConstSnakeCase = {
                   node: decl.id,
                   messageId: "topLevelConstCaps",
                   data: { name: decl.id.name },
+                  fix(fixer) {
+                    const newName = toUpperSnake(decl.id.name);
+                    const sourceCode = context.sourceCode;
+                    const scope = sourceCode.getScope(node);
+                    let variable = null;
+                    let currentScope = scope;
+                    while (currentScope) {
+                      variable = currentScope.variables.find(
+                        (v) => v.name === decl.id.name,
+                      );
+                      if (variable) break;
+                      currentScope = currentScope.upper;
+                    }
+                    if (!variable) return fixer.replaceText(decl.id, newName);
+                    const fixes = [fixer.replaceText(decl.id, newName)];
+                    for (const ref of variable.references) {
+                      if (ref.identifier !== decl.id) {
+                        fixes.push(fixer.replaceText(ref.identifier, newName));
+                      }
+                    }
+                    return fixes;
+                  },
                 });
               }
             }

--- a/lib/rules/react/enforce-event-handler-naming.js
+++ b/lib/rules/react/enforce-event-handler-naming.js
@@ -1,0 +1,105 @@
+/**
+ * @fileoverview Enforce event handler naming conventions in React components.
+ * Props callbacks should use "on" prefix, internal handlers should use "handle" prefix.
+ */
+const micromatch = require("micromatch");
+
+const EVENT_PROP_REGEX = /^on[A-Z]/;
+const HANDLER_REGEX = /^handle[A-Z]/;
+
+module.exports = {
+  meta: {
+    type: "suggestion",
+    docs: {
+      description:
+        'Enforce event handler naming: "on*" for props, "handle*" for internal handlers.',
+      category: "Best Practices",
+    },
+    messages: {
+      handlerPropNaming:
+        'Event handler prop "{{name}}" should start with "on" (e.g., "on{{expected}}").',
+      handlerFuncNaming:
+        'Event handler function "{{name}}" passed to "{{prop}}" should start with "handle" (e.g., "handle{{expected}}").',
+    },
+    fixable: "code",
+    schema: [
+      {
+        type: "object",
+        properties: {
+          ignore: {
+            type: "array",
+            items: { type: "string" },
+          },
+        },
+        additionalProperties: false,
+      },
+    ],
+  },
+  create(context) {
+    const filename = context.filename;
+    const options = context.options[0] || {};
+    const ignorePatterns = options.ignore || [];
+    if (ignorePatterns.length && micromatch.isMatch(filename, ignorePatterns))
+      return {};
+    return {
+      JSXAttribute(node) {
+        if (!node.name || !node.name.name) return;
+        const propName = node.name.name;
+        // Only check on* props that look like event handlers
+        if (!EVENT_PROP_REGEX.test(propName)) return;
+        // Check if the value is an identifier (handler reference)
+        if (
+          node.value &&
+          node.value.type === "JSXExpressionContainer" &&
+          node.value.expression &&
+          node.value.expression.type === "Identifier"
+        ) {
+          const handlerName = node.value.expression.name;
+          // Handler passed to on* prop should start with "handle"
+          if (
+            !HANDLER_REGEX.test(handlerName) &&
+            !EVENT_PROP_REGEX.test(handlerName)
+          ) {
+            const eventPart = propName.slice(2); // Remove "on"
+            context.report({
+              node: node.value.expression,
+              messageId: "handlerFuncNaming",
+              data: {
+                name: handlerName,
+                prop: propName,
+                expected: eventPart,
+              },
+              fix(fixer) {
+                const newName = "handle" + eventPart;
+                const sourceCode = context.sourceCode;
+                const scope = sourceCode.getScope(node);
+                let variable = null;
+                let currentScope = scope;
+                while (currentScope) {
+                  variable = currentScope.variables.find(
+                    (v) => v.name === handlerName,
+                  );
+                  if (variable) break;
+                  currentScope = currentScope.upper;
+                }
+                if (!variable)
+                  return fixer.replaceText(node.value.expression, newName);
+                const fixes = [];
+                for (const ref of variable.references) {
+                  fixes.push(fixer.replaceText(ref.identifier, newName));
+                }
+                // Also rename definition
+                for (const def of variable.defs) {
+                  if (def.name && def.name !== node.value.expression) {
+                    fixes.push(fixer.replaceText(def.name, newName));
+                  }
+                }
+                return fixes;
+              },
+            });
+          }
+        }
+      },
+    };
+  },
+};

--- a/lib/rules/react/enforce-no-empty-classname-utility.js
+++ b/lib/rules/react/enforce-no-empty-classname-utility.js
@@ -11,6 +11,8 @@ module.exports = {
       description: "Disallow empty className strings",
       category: "Best Practices",
     },
+    fixable: "code",
+    schema: [],
     messages: {
       emptyClassName:
         "Empty className string found. Remove it or add valid classes.",
@@ -28,6 +30,9 @@ module.exports = {
               context.report({
                 node: value,
                 messageId: "emptyClassName",
+                fix(fixer) {
+                  return fixer.remove(node);
+                },
               });
             }
           } else if (value?.type === "JSXExpressionContainer") {
@@ -42,6 +47,9 @@ module.exports = {
               context.report({
                 node: expression,
                 messageId: "emptyClassName",
+                fix(fixer) {
+                  return fixer.remove(node);
+                },
               });
             }
             // className={``} or className={`   `}
@@ -53,6 +61,9 @@ module.exports = {
               context.report({
                 node: expression,
                 messageId: "emptyClassName",
+                fix(fixer) {
+                  return fixer.remove(node);
+                },
               });
             }
           }

--- a/lib/rules/react/enforce-use-state-naming.js
+++ b/lib/rules/react/enforce-use-state-naming.js
@@ -1,0 +1,110 @@
+/**
+ * @fileoverview Enforce that useState destructuring follows [value, setValue] convention.
+ * The setter should be the camelCase name prefixed with "set".
+ */
+const micromatch = require("micromatch");
+
+module.exports = {
+  meta: {
+    type: "suggestion",
+    docs: {
+      description:
+        "Enforce useState destructuring follows [value, setValue] naming convention.",
+      category: "Best Practices",
+    },
+    messages: {
+      useStateNaming:
+        'useState setter "{{setter}}" should be named "set{{expected}}" to match state variable "{{state}}".',
+    },
+    fixable: "code",
+    schema: [
+      {
+        type: "object",
+        properties: {
+          ignore: {
+            type: "array",
+            items: { type: "string" },
+          },
+        },
+        additionalProperties: false,
+      },
+    ],
+  },
+  create(context) {
+    const filename = context.filename;
+    const options = context.options[0] || {};
+    const ignorePatterns = options.ignore || [];
+    if (ignorePatterns.length && micromatch.isMatch(filename, ignorePatterns))
+      return {};
+    return {
+      VariableDeclarator(node) {
+        // Match: const [x, setX] = useState(...)
+        if (
+          !node.init ||
+          node.init.type !== "CallExpression" ||
+          !node.id ||
+          node.id.type !== "ArrayPattern"
+        )
+          return;
+        const callee = node.init.callee;
+        // Check if it's a useState call (useState or React.useState)
+        const isUseState =
+          (callee.type === "Identifier" && callee.name === "useState") ||
+          (callee.type === "MemberExpression" &&
+            callee.object.name === "React" &&
+            callee.property.name === "useState");
+        if (!isUseState) return;
+        const elements = node.id.elements;
+        if (!elements || elements.length !== 2) return;
+        const [stateNode, setterNode] = elements;
+        if (
+          !stateNode ||
+          !setterNode ||
+          stateNode.type !== "Identifier" ||
+          setterNode.type !== "Identifier"
+        )
+          return;
+        const stateName = stateNode.name;
+        const setterName = setterNode.name;
+        const expectedSetter =
+          "set" + stateName.charAt(0).toUpperCase() + stateName.slice(1);
+        if (setterName !== expectedSetter) {
+          context.report({
+            node: setterNode,
+            messageId: "useStateNaming",
+            data: {
+              setter: setterName,
+              expected: stateName.charAt(0).toUpperCase() + stateName.slice(1),
+              state: stateName,
+            },
+            fix(fixer) {
+              const sourceCode = context.sourceCode;
+              const scope = sourceCode.getScope(node);
+              // Find all references to the setter in the current scope
+              let variable = null;
+              let currentScope = scope;
+              while (currentScope) {
+                variable = currentScope.variables.find(
+                  (v) => v.name === setterName,
+                );
+                if (variable) break;
+                currentScope = currentScope.upper;
+              }
+              if (!variable) return null;
+              const fixes = [];
+              // Rename the declaration
+              fixes.push(fixer.replaceText(setterNode, expectedSetter));
+              // Rename all references
+              for (const ref of variable.references) {
+                if (ref.identifier !== setterNode) {
+                  fixes.push(fixer.replaceText(ref.identifier, expectedSetter));
+                }
+              }
+              return fixes;
+            },
+          });
+        }
+      },
+    };
+  },
+};

--- a/lib/rules/react/no-inline-arrow-functions-in-jsx.js
+++ b/lib/rules/react/no-inline-arrow-functions-in-jsx.js
@@ -26,7 +26,7 @@ const rule = {
     ],
   },
   create(context) {
-    const filename = context.getFilename();
+    const filename = context.filename;
     const options = context.options[0] || {};
     const ignorePatterns = options.ignore || [];
     if (ignorePatterns.length) {

--- a/lib/rules/react/no-nested-component.js
+++ b/lib/rules/react/no-nested-component.js
@@ -43,7 +43,7 @@ const rule = {
     let micromatch;
     if (ignorePatterns.length) {
       micromatch = require("micromatch");
-      const filename = context.getFilename();
+      const filename = context.filename;
       if (micromatch.isMatch(filename, ignorePatterns)) return {};
     }
 

--- a/lib/rules/react/no-unnecessary-fragment.js
+++ b/lib/rules/react/no-unnecessary-fragment.js
@@ -19,6 +19,7 @@ const rule = {
         "Warn if React fragments are unnecessary (e.g., wrapping a single child).",
       category: "Best Practices",
     },
+    fixable: "code",
     messages: {
       unnecessaryFragment:
         "Unnecessary React fragment: consider removing the fragment wrapper.",
@@ -26,6 +27,14 @@ const rule = {
     schema: [],
   },
   create(context) {
+    const sourceCode = context.sourceCode;
+
+    function fixFragment(fixer, node, children) {
+      const child = children[0];
+      const childText = sourceCode.getText(child);
+      return fixer.replaceText(node, childText);
+    }
+
     return {
       JSXFragment(node) {
         const children = getMeaningfulChildren(node.children);
@@ -33,6 +42,9 @@ const rule = {
           context.report({
             node,
             messageId: "unnecessaryFragment",
+            fix(fixer) {
+              return fixFragment(fixer, node, children);
+            },
           });
         }
       },
@@ -43,6 +55,9 @@ const rule = {
             context.report({
               node,
               messageId: "unnecessaryFragment",
+              fix(fixer) {
+                return fixFragment(fixer, node, children);
+              },
             });
           }
         }

--- a/lib/rules/testing/enforce-testid-naming.js
+++ b/lib/rules/testing/enforce-testid-naming.js
@@ -1,0 +1,90 @@
+/**
+ * @fileoverview Enforce consistent test ID attribute naming.
+ * Ensures that data-testid attributes use kebab-case and follow a naming convention.
+ */
+const micromatch = require("micromatch");
+
+const KEBAB_CASE_REGEX = /^[a-z][a-z0-9]*(-[a-z0-9]+)*$/;
+
+module.exports = {
+  meta: {
+    type: "suggestion",
+    docs: {
+      description:
+        "Enforce that data-testid attributes in JSX use consistent kebab-case naming.",
+      category: "Best Practices",
+    },
+    fixable: "code",
+    messages: {
+      invalidTestId:
+        'data-testid "{{value}}" should be in kebab-case (e.g., "my-component-button").',
+    },
+    schema: [
+      {
+        type: "object",
+        properties: {
+          ignore: {
+            type: "array",
+            items: { type: "string" },
+          },
+          testIdAttribute: {
+            type: "string",
+            description: "The attribute name to check (default: data-testid).",
+          },
+        },
+        additionalProperties: false,
+      },
+    ],
+  },
+  create(context) {
+    const filename = context.filename;
+    const options = context.options[0] || {};
+    const ignorePatterns = options.ignore || [];
+    const testIdAttribute = options.testIdAttribute || "data-testid";
+    if (ignorePatterns.length && micromatch.isMatch(filename, ignorePatterns))
+      return {};
+
+    function toKebabCase(str) {
+      return str
+        .replace(/([a-z0-9])([A-Z])/g, "$1-$2")
+        .replace(/([A-Z]+)([A-Z][a-z])/g, "$1-$2")
+        .replace(/[_\s]+/g, "-")
+        .toLowerCase();
+    }
+
+    return {
+      JSXAttribute(node) {
+        if (!node.name || node.name.name !== testIdAttribute) return;
+        if (!node.value) return;
+        let value = null;
+        if (
+          node.value.type === "Literal" &&
+          typeof node.value.value === "string"
+        ) {
+          value = node.value.value;
+        } else if (
+          node.value.type === "JSXExpressionContainer" &&
+          node.value.expression.type === "Literal" &&
+          typeof node.value.expression.value === "string"
+        ) {
+          value = node.value.expression.value;
+        }
+        if (!value) return;
+        if (!KEBAB_CASE_REGEX.test(value)) {
+          context.report({
+            node: node.value,
+            messageId: "invalidTestId",
+            data: { value },
+            fix(fixer) {
+              const fixed = toKebabCase(value);
+              if (node.value.type === "Literal") {
+                return fixer.replaceText(node.value, `"${fixed}"`);
+              }
+              return fixer.replaceText(node.value, `{"${fixed}"}`);
+            },
+          });
+        }
+      },
+    };
+  },
+};

--- a/lib/rules/typescript/enforce-enum-member-naming.js
+++ b/lib/rules/typescript/enforce-enum-member-naming.js
@@ -1,0 +1,73 @@
+/**
+ * @fileoverview Enforce consistent naming for TypeScript enum members.
+ * Enum members should be in PascalCase or UPPER_SNAKE_CASE.
+ */
+const micromatch = require("micromatch");
+
+const PASCAL_CASE_REGEX = /^[A-Z][A-Za-z0-9]*$/;
+const UPPER_SNAKE_REGEX = /^[A-Z][A-Z0-9_]*$/;
+
+module.exports = {
+  meta: {
+    type: "suggestion",
+    docs: {
+      description:
+        "Enforce that TypeScript enum members use PascalCase or UPPER_SNAKE_CASE naming.",
+      category: "Best Practices",
+    },
+    messages: {
+      badEnumMemberName:
+        'Enum member "{{name}}" should be in PascalCase or UPPER_SNAKE_CASE.',
+    },
+    schema: [
+      {
+        type: "object",
+        properties: {
+          convention: {
+            type: "string",
+            enum: ["PascalCase", "UPPER_SNAKE_CASE", "both"],
+            description:
+              "Which naming convention to enforce. Default: both (allows either).",
+          },
+          ignore: {
+            type: "array",
+            items: { type: "string" },
+          },
+        },
+        additionalProperties: false,
+      },
+    ],
+  },
+  create(context) {
+    const filename = context.filename;
+    if (!filename.endsWith(".ts") && !filename.endsWith(".tsx")) return {};
+    const options = context.options[0] || {};
+    const convention = options.convention || "both";
+    const ignorePatterns = options.ignore || [];
+    if (ignorePatterns.length && micromatch.isMatch(filename, ignorePatterns))
+      return {};
+
+    function isValidName(name) {
+      if (convention === "PascalCase") return PASCAL_CASE_REGEX.test(name);
+      if (convention === "UPPER_SNAKE_CASE")
+        return UPPER_SNAKE_REGEX.test(name);
+      return PASCAL_CASE_REGEX.test(name) || UPPER_SNAKE_REGEX.test(name);
+    }
+
+    return {
+      TSEnumMember(node) {
+        const key = node.id;
+        if (!key) return;
+        const name = key.type === "Identifier" ? key.name : null;
+        if (!name) return;
+        if (!isValidName(name)) {
+          context.report({
+            node: key,
+            messageId: "badEnumMemberName",
+            data: { name },
+          });
+        }
+      },
+    };
+  },
+};

--- a/lib/rules/typescript/interface-type-required-first.js
+++ b/lib/rules/typescript/interface-type-required-first.js
@@ -8,6 +8,7 @@ const rule = {
         "Require all required fields to come before optional fields in interfaces and types.",
       category: "Best Practices",
     },
+    fixable: "code",
     messages: {
       requiredBeforeOptional:
         "Required field '{{name}}' should come before all optional fields in '{{parent}}'.",
@@ -26,7 +27,7 @@ const rule = {
     ],
   },
   create(context) {
-    const filename = context.getFilename();
+    const filename = context.filename;
     if (!filename.endsWith(".ts") && !filename.endsWith(".tsx")) return {};
     const options = context.options[0] || {};
     const ignorePatterns = options.ignore || [];
@@ -34,7 +35,8 @@ const rule = {
       const micromatch = require("micromatch");
       if (micromatch.isMatch(filename, ignorePatterns)) return {};
     }
-    function checkFields(node, parentName) {
+    const sourceCode = context.sourceCode;
+    function checkFields(node, parentName, containerNode) {
       let members = [];
       // For TSInterfaceDeclaration: node.body.body is the array of members
       if (node.body && Array.isArray(node.body.body)) {
@@ -47,8 +49,8 @@ const rule = {
       // If no members, nothing to check
       if (!members.length) return;
       let foundOptional = false;
+      let needsFix = false;
       for (const member of members) {
-        // Check if the member is a property signature with a name
         if (
           member.type !== "TSPropertySignature" ||
           !member.key ||
@@ -59,12 +61,36 @@ const rule = {
         if (isOptional) {
           foundOptional = true;
         } else if (foundOptional) {
-          // Found a required field after an optional field
+          needsFix = true;
           context.report({
             node: member.key,
             messageId: "requiredBeforeOptional",
             data: { name: member.key.name, parent: parentName },
+            fix(fixer) {
+              // Reorder: required fields first, then optional
+              const propMembers = members.filter(
+                (m) => m.type === "TSPropertySignature" && m.key && m.key.name,
+              );
+              const required = propMembers.filter((m) => !m.optional);
+              const optional = propMembers.filter((m) => m.optional);
+              const nonPropMembers = members.filter(
+                (m) =>
+                  m.type !== "TSPropertySignature" || !m.key || !m.key.name,
+              );
+              const reordered = [...required, ...optional, ...nonPropMembers];
+              const reorderedText = reordered
+                .map((m) => sourceCode.getText(m))
+                .join("\n");
+              const firstMember = members[0];
+              const lastMember = members[members.length - 1];
+              return fixer.replaceTextRange(
+                [firstMember.range[0], lastMember.range[1]],
+                reorderedText,
+              );
+            },
           });
+          // Only report first violation per block, fixer handles all
+          return;
         }
       }
     }

--- a/lib/utils/documentation.js
+++ b/lib/utils/documentation.js
@@ -2,7 +2,7 @@ function hasJSDoc(node, sourceCode) {
   const jsdoc = sourceCode
     .getCommentsBefore(node)
     .find(
-      (comment) => comment.type === "Block" && comment.value.startsWith("*")
+      (comment) => comment.type === "Block" && comment.value.startsWith("*"),
     );
   return Boolean(jsdoc);
 }
@@ -29,6 +29,7 @@ function createJsdocRule({ typePredicate, messageId, defaultMessage }) {
         category: "Documentation",
         recommended: false,
       },
+      fixable: "code",
       schema: [
         {
           type: "object",
@@ -50,14 +51,14 @@ function createJsdocRule({ typePredicate, messageId, defaultMessage }) {
     create(context) {
       const options = context.options[0] || {};
       const folders = options.folders || null;
-      const filename = context.getFilename();
+      const filename = context.filename;
       if (
         folders &&
         !folders.some((pattern) => micromatch.isMatch(filename, pattern))
       ) {
         return {};
       }
-      const sourceCode = context.getSourceCode();
+      const sourceCode = context.sourceCode;
       function check(node) {
         if (!isRootLevel(node)) return;
         const name = node.id ? node.id.name : null;
@@ -67,6 +68,10 @@ function createJsdocRule({ typePredicate, messageId, defaultMessage }) {
           node,
           messageId,
           data: { name: name || "(anonymous)" },
+          fix(fixer) {
+            const jsdoc = `/** ${defaultMessage.replace("{{name}}", name || "(anonymous)").replace(/\. *$/, "")} */\n`;
+            return fixer.insertTextBefore(node, jsdoc);
+          },
         });
       }
       return {
@@ -86,6 +91,10 @@ function createJsdocRule({ typePredicate, messageId, defaultMessage }) {
                 node: decl,
                 messageId,
                 data: { name: name || "(anonymous)" },
+                fix(fixer) {
+                  const jsdoc = `/** ${defaultMessage.replace("{{name}}", name || "(anonymous)").replace(/\. *$/, "")} */\n`;
+                  return fixer.insertTextBefore(node, jsdoc);
+                },
               });
             }
           }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "eslint-frontend-rules",
-  "version": "1.0.6",
+  "version": "3.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "eslint-frontend-rules",
-      "version": "1.0.6",
+      "version": "3.0.0",
       "license": "MIT",
       "dependencies": {
         "micromatch": "^4.0.8"
@@ -17,13 +17,13 @@
         "rollup": "^4.45.1"
       },
       "peerDependencies": {
-        "eslint": ">=7.0.0"
+        "eslint": ">=9.0.0"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.7.0.tgz",
-      "integrity": "sha512-dyybb3AcajC7uha6CvhdVRJqaKyn7w2YKqKyAN37NKYgZT36w+iRb0Dymmc5qEJ549c/S31cMMSFd75bteCpCw==",
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+      "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -53,9 +53,9 @@
       }
     },
     "node_modules/@eslint-community/regexpp": {
-      "version": "4.12.1",
-      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.1.tgz",
-      "integrity": "sha512-CCZCDJuduB9OUkFkY2IgppNZMi2lBQgD2qzwXkEia16cge2pijY/aXi96CJMquDMn3nJdlPV1A5KrJEXwfLNzQ==",
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
       "license": "MIT",
       "peer": true,
       "engines": {
@@ -63,115 +63,68 @@
       }
     },
     "node_modules/@eslint/config-array": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.20.1.tgz",
-      "integrity": "sha512-OL0RJzC/CBzli0DrrR31qzj6d6i6Mm3HByuhflhl4LOBiWxN+3i6/t/ZQQNii4tjksXi8r2CRW1wMpWA2ULUEw==",
+      "version": "0.23.3",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.23.3.tgz",
+      "integrity": "sha512-j+eEWmB6YYLwcNOdlwQ6L2OsptI/LO6lNBuLIqe5R7RetD658HLoF+Mn7LzYmAWWNNzdC6cqP+L6r8ujeYXWLw==",
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
-        "@eslint/object-schema": "^2.1.6",
+        "@eslint/object-schema": "^3.0.3",
         "debug": "^4.3.1",
-        "minimatch": "^3.1.2"
+        "minimatch": "^10.2.4"
       },
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       }
     },
     "node_modules/@eslint/config-helpers": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.2.3.tgz",
-      "integrity": "sha512-u180qk2Um1le4yf0ruXH3PYFeEZeYC3p/4wCTKrr2U1CmGdzGi3KtY0nuPDH48UJxlKCC5RDzbcbh4X0XlqgHg==",
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.5.3.tgz",
+      "integrity": "sha512-lzGN0onllOZCGroKJmRwY6QcEHxbjBw1gwB8SgRSqK8YbbtEXMvKynsXc3553ckIEBxsbMBU7oOZXKIPGZNeZw==",
       "license": "Apache-2.0",
       "peer": true,
+      "dependencies": {
+        "@eslint/core": "^1.1.1"
+      },
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       }
     },
     "node_modules/@eslint/core": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.14.0.tgz",
-      "integrity": "sha512-qIbV0/JZr7iSDjqAc60IqbLdsj9GDt16xQtWD+B78d/HAlvysGdZZ6rpJHGAc2T0FQx1X6thsSPdnoiGKdNtdg==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.1.1.tgz",
+      "integrity": "sha512-QUPblTtE51/7/Zhfv8BDwO0qkkzQL7P/aWWbqcf4xWLEYn1oKjdO0gglQBB4GAsu7u6wjijbCmzsUTy6mnk6oQ==",
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
         "@types/json-schema": "^7.0.15"
       },
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      }
-    },
-    "node_modules/@eslint/eslintrc": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.1.tgz",
-      "integrity": "sha512-gtF186CXhIl1p4pJNGZw8Yc6RlshoePRvE0X91oPGb3vZ8pM3qOS9W9NGPat9LziaBV7XrJWGylNQXkGcnM3IQ==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "ajv": "^6.12.4",
-        "debug": "^4.3.2",
-        "espree": "^10.0.1",
-        "globals": "^14.0.0",
-        "ignore": "^5.2.0",
-        "import-fresh": "^3.2.1",
-        "js-yaml": "^4.1.0",
-        "minimatch": "^3.1.2",
-        "strip-json-comments": "^3.1.1"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/@eslint/js": {
-      "version": "9.29.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.29.0.tgz",
-      "integrity": "sha512-3PIF4cBw/y+1u2EazflInpV+lYsSG0aByVIQzAgb1m1MhHFSbqTyNqtBKHgWf/9Ykud+DhILS9EGkmekVhbKoQ==",
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "url": "https://eslint.org/donate"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       }
     },
     "node_modules/@eslint/object-schema": {
-      "version": "2.1.6",
-      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.6.tgz",
-      "integrity": "sha512-RBMg5FRL0I0gs51M/guSAj5/e14VQ4tpZnQNWwuDT66P14I43ItmPfIZRhO9fUVIPOAQXU47atlywZ/czoqFPA==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-3.0.3.tgz",
+      "integrity": "sha512-iM869Pugn9Nsxbh/YHRqYiqd23AmIbxJOcpUMOuWCVNdoQJ5ZtwL6h3t0bcZzJUlC3Dq9jCFCESBZnX0GTv7iQ==",
       "license": "Apache-2.0",
       "peer": true,
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       }
     },
     "node_modules/@eslint/plugin-kit": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.3.3.tgz",
-      "integrity": "sha512-1+WqvgNMhmlAambTvT3KPtCl/Ibr68VldY2XY40SL1CE0ZXiakFR/cbTspaF5HsnpDMvcYYoJHfl4980NBjGag==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.6.1.tgz",
+      "integrity": "sha512-iH1B076HoAshH1mLpHMgwdGeTs0CYwL0SPMkGuSebZrwBp16v415e9NZXg2jtrqPVQjf6IANe2Vtlr5KswtcZQ==",
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
-        "@eslint/core": "^0.15.1",
+        "@eslint/core": "^1.1.1",
         "levn": "^0.4.1"
       },
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      }
-    },
-    "node_modules/@eslint/plugin-kit/node_modules/@eslint/core": {
-      "version": "0.15.1",
-      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.15.1.tgz",
-      "integrity": "sha512-bkOp+iumZCCbt1K1CmWf0R9pM5yKpDv+ZXtvSyQpudrI9kuFLp+bM2WOPXImuD/ceQuaa8f5pj93Y7zyECIGNA==",
-      "license": "Apache-2.0",
-      "peer": true,
-      "dependencies": {
-        "@types/json-schema": "^7.0.15"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       }
     },
     "node_modules/@humanfs/core": {
@@ -185,31 +138,17 @@
       }
     },
     "node_modules/@humanfs/node": {
-      "version": "0.16.6",
-      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.6.tgz",
-      "integrity": "sha512-YuI2ZHQL78Q5HbhDiBA1X4LmYdXCKCMQIfw0pw7piHJwyREFebJUvrQN4cMssyES6x+vfUbx1CIpaQUKYdQZOw==",
+      "version": "0.16.7",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.7.tgz",
+      "integrity": "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==",
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
         "@humanfs/core": "^0.19.1",
-        "@humanwhocodes/retry": "^0.3.0"
+        "@humanwhocodes/retry": "^0.4.0"
       },
       "engines": {
         "node": ">=18.18.0"
-      }
-    },
-    "node_modules/@humanfs/node/node_modules/@humanwhocodes/retry": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.3.1.tgz",
-      "integrity": "sha512-JBxkERygn7Bv/GbN5Rv8Ul6LVknS+5Bp6RgDC/O8gEBU/yeH5Ui5C/OlWrTb6qct7LjjfT6Re2NxB0ln0yYybA==",
-      "license": "Apache-2.0",
-      "peer": true,
-      "engines": {
-        "node": ">=18.18"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/nzakas"
       }
     },
     "node_modules/@humanwhocodes/module-importer": {
@@ -241,16 +180,16 @@
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.5.4",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.4.tgz",
-      "integrity": "sha512-VT2+G1VQs/9oz078bLrYbecdZKs912zQlkelYpuf+SXF+QvZDYJlbx/LSx+meSAwdDFnF8FVXW92AVjjkVmgFw==",
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@rollup/plugin-commonjs": {
-      "version": "28.0.6",
-      "resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-28.0.6.tgz",
-      "integrity": "sha512-XSQB1K7FUU5QP+3lOQmVCE3I0FcbbNvmNT4VJSj93iUjayaARrTQeoRdiYQoftAJBLrR9t2agwAd3ekaTgHNlw==",
+      "version": "28.0.9",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-28.0.9.tgz",
+      "integrity": "sha512-PIR4/OHZ79romx0BVVll/PkwWpJ7e5lsqFa3gFfcrFPWwLXLV39JVUzQV9RKjWerE7B845Hqjj9VYlQeieZ2dA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -274,38 +213,10 @@
         }
       }
     },
-    "node_modules/@rollup/plugin-commonjs/node_modules/fdir": {
-      "version": "6.4.6",
-      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.6.tgz",
-      "integrity": "sha512-hiFoqpyZcfNm1yc4u8oWCf9A2c4D3QjCrks3zmoVKVxpQRzmPNar1hUJcBG2RQHvEVGDN+Jm81ZheVLAQMK6+w==",
-      "dev": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "picomatch": "^3 || ^4"
-      },
-      "peerDependenciesMeta": {
-        "picomatch": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@rollup/plugin-commonjs/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
     "node_modules/@rollup/plugin-node-resolve": {
-      "version": "16.0.1",
-      "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-16.0.1.tgz",
-      "integrity": "sha512-tk5YCxJWIG81umIvNkSod2qK5KyQW19qcBF/B78n1bjtOON6gzKoVeSzAE8yHCZEDmqkHKkxplExA8KzdJLJpA==",
+      "version": "16.0.3",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-16.0.3.tgz",
+      "integrity": "sha512-lUYM3UBGuM93CnMPG1YocWu7X802BrNF3jW2zny5gQyLQgRFJhV1Sq0Zi74+dh/6NBx1DxFC4b4GXg9wUCG5Qg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -328,9 +239,9 @@
       }
     },
     "node_modules/@rollup/pluginutils": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.2.0.tgz",
-      "integrity": "sha512-qWJ2ZTbmumwiLFomfzTyt5Kng4hwPi9rwCYN4SHb6eaRU1KNO4ccxINHr/VhH4GgPlt1XfSTLX2LBTme8ne4Zw==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.3.0.tgz",
+      "integrity": "sha512-5EdhGZtnu3V88ces7s53hhfK5KSASnJZv8Lulpc04cWO3REESroJXg73DFsOmgbU2BhwV0E20bu2IDZb3VKW4Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -350,23 +261,10 @@
         }
       }
     },
-    "node_modules/@rollup/pluginutils/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
     "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.45.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.45.1.tgz",
-      "integrity": "sha512-NEySIFvMY0ZQO+utJkgoMiCAjMrGvnbDLHvcmlA33UXJpYBCvlBEbMMtV837uCkS+plG2umfhn0T5mMAxGrlRA==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.1.tgz",
+      "integrity": "sha512-d6FinEBLdIiK+1uACUttJKfgZREXrF0Qc2SmLII7W2AD8FfiZ9Wjd+rD/iRuf5s5dWrr1GgwXCvPqOuDquOowA==",
       "cpu": [
         "arm"
       ],
@@ -378,9 +276,9 @@
       ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.45.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.45.1.tgz",
-      "integrity": "sha512-ujQ+sMXJkg4LRJaYreaVx7Z/VMgBBd89wGS4qMrdtfUFZ+TSY5Rs9asgjitLwzeIbhwdEhyj29zhst3L1lKsRQ==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.1.tgz",
+      "integrity": "sha512-YjG/EwIDvvYI1YvYbHvDz/BYHtkY4ygUIXHnTdLhG+hKIQFBiosfWiACWortsKPKU/+dUwQQCKQM3qrDe8c9BA==",
       "cpu": [
         "arm64"
       ],
@@ -392,9 +290,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.45.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.45.1.tgz",
-      "integrity": "sha512-FSncqHvqTm3lC6Y13xncsdOYfxGSLnP+73k815EfNmpewPs+EyM49haPS105Rh4aF5mJKywk9X0ogzLXZzN9lA==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.1.tgz",
+      "integrity": "sha512-mjCpF7GmkRtSJwon+Rq1N8+pI+8l7w5g9Z3vWj4T7abguC4Czwi3Yu/pFaLvA3TTeMVjnu3ctigusqWUfjZzvw==",
       "cpu": [
         "arm64"
       ],
@@ -406,9 +304,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.45.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.45.1.tgz",
-      "integrity": "sha512-2/vVn/husP5XI7Fsf/RlhDaQJ7x9zjvC81anIVbr4b/f0xtSmXQTFcGIQ/B1cXIYM6h2nAhJkdMHTnD7OtQ9Og==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.1.tgz",
+      "integrity": "sha512-haZ7hJ1JT4e9hqkoT9R/19XW2QKqjfJVv+i5AGg57S+nLk9lQnJ1F/eZloRO3o9Scy9CM3wQ9l+dkXtcBgN5Ew==",
       "cpu": [
         "x64"
       ],
@@ -420,9 +318,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.45.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.45.1.tgz",
-      "integrity": "sha512-4g1kaDxQItZsrkVTdYQ0bxu4ZIQ32cotoQbmsAnW1jAE4XCMbcBPDirX5fyUzdhVCKgPcrwWuucI8yrVRBw2+g==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.1.tgz",
+      "integrity": "sha512-czw90wpQq3ZsAVBlinZjAYTKduOjTywlG7fEeWKUA7oCmpA8xdTkxZZlwNJKWqILlq0wehoZcJYfBvOyhPTQ6w==",
       "cpu": [
         "arm64"
       ],
@@ -434,9 +332,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.45.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.45.1.tgz",
-      "integrity": "sha512-L/6JsfiL74i3uK1Ti2ZFSNsp5NMiM4/kbbGEcOCps99aZx3g8SJMO1/9Y0n/qKlWZfn6sScf98lEOUe2mBvW9A==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.1.tgz",
+      "integrity": "sha512-KVB2rqsxTHuBtfOeySEyzEOB7ltlB/ux38iu2rBQzkjbwRVlkhAGIEDiiYnO2kFOkJp+Z7pUXKyrRRFuFUKt+g==",
       "cpu": [
         "x64"
       ],
@@ -448,9 +346,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.45.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.45.1.tgz",
-      "integrity": "sha512-RkdOTu2jK7brlu+ZwjMIZfdV2sSYHK2qR08FUWcIoqJC2eywHbXr0L8T/pONFwkGukQqERDheaGTeedG+rra6Q==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.1.tgz",
+      "integrity": "sha512-L+34Qqil+v5uC0zEubW7uByo78WOCIrBvci69E7sFASRl0X7b/MB6Cqd1lky/CtcSVTydWa2WZwFuWexjS5o6g==",
       "cpu": [
         "arm"
       ],
@@ -462,9 +360,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.45.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.45.1.tgz",
-      "integrity": "sha512-3kJ8pgfBt6CIIr1o+HQA7OZ9mp/zDk3ctekGl9qn/pRBgrRgfwiffaUmqioUGN9hv0OHv2gxmvdKOkARCtRb8Q==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.1.tgz",
+      "integrity": "sha512-n83O8rt4v34hgFzlkb1ycniJh7IR5RCIqt6mz1VRJD6pmhRi0CXdmfnLu9dIUS6buzh60IvACM842Ffb3xd6Gg==",
       "cpu": [
         "arm"
       ],
@@ -476,9 +374,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.45.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.45.1.tgz",
-      "integrity": "sha512-k3dOKCfIVixWjG7OXTCOmDfJj3vbdhN0QYEqB+OuGArOChek22hn7Uy5A/gTDNAcCy5v2YcXRJ/Qcnm4/ma1xw==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.1.tgz",
+      "integrity": "sha512-Nql7sTeAzhTAja3QXeAI48+/+GjBJ+QmAH13snn0AJSNL50JsDqotyudHyMbO2RbJkskbMbFJfIJKWA6R1LCJQ==",
       "cpu": [
         "arm64"
       ],
@@ -490,9 +388,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.45.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.45.1.tgz",
-      "integrity": "sha512-PmI1vxQetnM58ZmDFl9/Uk2lpBBby6B6rF4muJc65uZbxCs0EA7hhKCk2PKlmZKuyVSHAyIw3+/SiuMLxKxWog==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.1.tgz",
+      "integrity": "sha512-+pUymDhd0ys9GcKZPPWlFiZ67sTWV5UU6zOJat02M1+PiuSGDziyRuI/pPue3hoUwm2uGfxdL+trT6Z9rxnlMA==",
       "cpu": [
         "arm64"
       ],
@@ -503,10 +401,10 @@
         "linux"
       ]
     },
-    "node_modules/@rollup/rollup-linux-loongarch64-gnu": {
-      "version": "4.45.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.45.1.tgz",
-      "integrity": "sha512-9UmI0VzGmNJ28ibHW2GpE2nF0PBQqsyiS4kcJ5vK+wuwGnV5RlqdczVocDSUfGX/Na7/XINRVoUgJyFIgipoRg==",
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.1.tgz",
+      "integrity": "sha512-VSvgvQeIcsEvY4bKDHEDWcpW4Yw7BtlKG1GUT4FzBUlEKQK0rWHYBqQt6Fm2taXS+1bXvJT6kICu5ZwqKCnvlQ==",
       "cpu": [
         "loong64"
       ],
@@ -517,10 +415,38 @@
         "linux"
       ]
     },
-    "node_modules/@rollup/rollup-linux-powerpc64le-gnu": {
-      "version": "4.45.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.45.1.tgz",
-      "integrity": "sha512-7nR2KY8oEOUTD3pBAxIBBbZr0U7U+R9HDTPNy+5nVVHDXI4ikYniH1oxQz9VoB5PbBU1CZuDGHkLJkd3zLMWsg==",
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.1.tgz",
+      "integrity": "sha512-4LqhUomJqwe641gsPp6xLfhqWMbQV04KtPp7/dIp0nzPxAkNY1AbwL5W0MQpcalLYk07vaW9Kp1PBhdpZYYcEw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.1.tgz",
+      "integrity": "sha512-tLQQ9aPvkBxOc/EUT6j3pyeMD6Hb8QF2BTBnCQWP/uu1lhc9AIrIjKnLYMEroIz/JvtGYgI9dF3AxHZNaEH0rw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.1.tgz",
+      "integrity": "sha512-RMxFhJwc9fSXP6PqmAz4cbv3kAyvD1etJFjTx4ONqFP9DkTkXsAMU4v3Vyc5BgzC+anz7nS/9tp4obsKfqkDHg==",
       "cpu": [
         "ppc64"
       ],
@@ -532,9 +458,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.45.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.45.1.tgz",
-      "integrity": "sha512-nlcl3jgUultKROfZijKjRQLUu9Ma0PeNv/VFHkZiKbXTBQXhpytS8CIj5/NfBeECZtY2FJQubm6ltIxm/ftxpw==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.1.tgz",
+      "integrity": "sha512-QKgFl+Yc1eEk6MmOBfRHYF6lTxiiiV3/z/BRrbSiW2I7AFTXoBFvdMEyglohPj//2mZS4hDOqeB0H1ACh3sBbg==",
       "cpu": [
         "riscv64"
       ],
@@ -546,9 +472,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
-      "version": "4.45.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.45.1.tgz",
-      "integrity": "sha512-HJV65KLS51rW0VY6rvZkiieiBnurSzpzore1bMKAhunQiECPuxsROvyeaot/tcK3A3aGnI+qTHqisrpSgQrpgA==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.1.tgz",
+      "integrity": "sha512-RAjXjP/8c6ZtzatZcA1RaQr6O1TRhzC+adn8YZDnChliZHviqIjmvFwHcxi4JKPSDAt6Uhf/7vqcBzQJy0PDJg==",
       "cpu": [
         "riscv64"
       ],
@@ -560,9 +486,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.45.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.45.1.tgz",
-      "integrity": "sha512-NITBOCv3Qqc6hhwFt7jLV78VEO/il4YcBzoMGGNxznLgRQf43VQDae0aAzKiBeEPIxnDrACiMgbqjuihx08OOw==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.1.tgz",
+      "integrity": "sha512-wcuocpaOlaL1COBYiA89O6yfjlp3RwKDeTIA0hM7OpmhR1Bjo9j31G1uQVpDlTvwxGn2nQs65fBFL5UFd76FcQ==",
       "cpu": [
         "s390x"
       ],
@@ -574,9 +500,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.45.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.45.1.tgz",
-      "integrity": "sha512-+E/lYl6qu1zqgPEnTrs4WysQtvc/Sh4fC2nByfFExqgYrqkKWp1tWIbe+ELhixnenSpBbLXNi6vbEEJ8M7fiHw==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.1.tgz",
+      "integrity": "sha512-77PpsFQUCOiZR9+LQEFg9GClyfkNXj1MP6wRnzYs0EeWbPcHs02AXu4xuUbM1zhwn3wqaizle3AEYg5aeoohhg==",
       "cpu": [
         "x64"
       ],
@@ -588,9 +514,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.45.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.45.1.tgz",
-      "integrity": "sha512-a6WIAp89p3kpNoYStITT9RbTbTnqarU7D8N8F2CV+4Cl9fwCOZraLVuVFvlpsW0SbIiYtEnhCZBPLoNdRkjQFw==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.1.tgz",
+      "integrity": "sha512-5cIATbk5vynAjqqmyBjlciMJl1+R/CwX9oLk/EyiFXDWd95KpHdrOJT//rnUl4cUcskrd0jCCw3wpZnhIHdD9w==",
       "cpu": [
         "x64"
       ],
@@ -601,10 +527,38 @@
         "linux"
       ]
     },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.1.tgz",
+      "integrity": "sha512-cl0w09WsCi17mcmWqqglez9Gk8isgeWvoUZ3WiJFYSR3zjBQc2J5/ihSjpl+VLjPqjQ/1hJRcqBfLjssREQILw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.1.tgz",
+      "integrity": "sha512-4Cv23ZrONRbNtbZa37mLSueXUCtN7MXccChtKpUnQNgF010rjrjfHx3QxkS2PI7LqGT5xXyYs1a7LbzAwT0iCA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.45.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.45.1.tgz",
-      "integrity": "sha512-T5Bi/NS3fQiJeYdGvRpTAP5P02kqSOpqiopwhj0uaXB6nzs5JVi2XMJb18JUSKhCOX8+UE1UKQufyD6Or48dJg==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.1.tgz",
+      "integrity": "sha512-i1okWYkA4FJICtr7KpYzFpRTHgy5jdDbZiWfvny21iIKky5YExiDXP+zbXzm3dUcFpkEeYNHgQ5fuG236JPq0g==",
       "cpu": [
         "arm64"
       ],
@@ -616,9 +570,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.45.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.45.1.tgz",
-      "integrity": "sha512-lxV2Pako3ujjuUe9jiU3/s7KSrDfH6IgTSQOnDWr9aJ92YsFd7EurmClK0ly/t8dzMkDtd04g60WX6yl0sGfdw==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.1.tgz",
+      "integrity": "sha512-u09m3CuwLzShA0EYKMNiFgcjjzwqtUMLmuCJLeZWjjOYA3IT2Di09KaxGBTP9xVztWyIWjVdsB2E9goMjZvTQg==",
       "cpu": [
         "ia32"
       ],
@@ -629,10 +583,10 @@
         "win32"
       ]
     },
-    "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.45.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.45.1.tgz",
-      "integrity": "sha512-M/fKi4sasCdM8i0aWJjCSFm2qEnYRR8AMLG2kxp6wD13+tMGA4Z1tVAuHkNRjud5SW2EM3naLuK35w9twvf6aA==",
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.1.tgz",
+      "integrity": "sha512-k+600V9Zl1CM7eZxJgMyTUzmrmhB/0XZnF4pRypKAlAgxmedUA+1v9R+XOFv56W4SlHEzfeMtzujLJD22Uz5zg==",
       "cpu": [
         "x64"
       ],
@@ -642,6 +596,27 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.1.tgz",
+      "integrity": "sha512-lWMnixq/QzxyhTV6NjQJ4SFo1J6PvOX8vUx5Wb4bBPsEb+8xZ89Bz6kOXpfXj9ak9AHTQVQzlgzBEc1SyM27xQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/esrecurse": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@types/esrecurse/-/esrecurse-4.3.1.tgz",
+      "integrity": "sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -664,9 +639,9 @@
       "license": "MIT"
     },
     "node_modules/acorn": {
-      "version": "8.15.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
-      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
       "peer": true,
       "bin": {
@@ -687,9 +662,9 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
+      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -703,45 +678,27 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
-    "node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
       "license": "MIT",
       "peer": true,
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
       "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+        "node": "18 || 20 || >=22"
       }
     },
-    "node_modules/argparse": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "license": "Python-2.0",
-      "peer": true
-    },
-    "node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "license": "MIT",
-      "peer": true
-    },
     "node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/braces": {
@@ -756,66 +713,12 @@
         "node": ">=8"
       }
     },
-    "node_modules/callsites": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
-      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "license": "MIT",
-      "peer": true
-    },
     "node_modules/commondir": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
       "integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/concat-map": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -833,9 +736,9 @@
       }
     },
     "node_modules/debug": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
-      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -881,34 +784,30 @@
       }
     },
     "node_modules/eslint": {
-      "version": "9.29.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.29.0.tgz",
-      "integrity": "sha512-GsGizj2Y1rCWDu6XoEekL3RLilp0voSePurjZIkxL3wlm5o5EC9VpgaP7lrCvjnkuLvzFBQWB3vWB3K5KQTveQ==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.1.0.tgz",
+      "integrity": "sha512-S9jlY/ELKEUwwQnqWDO+f+m6sercqOPSqXM5Go94l7DOmxHVDgmSFGWEzeE/gwgTAr0W103BWt0QLe/7mabIvA==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@eslint-community/eslint-utils": "^4.2.0",
-        "@eslint-community/regexpp": "^4.12.1",
-        "@eslint/config-array": "^0.20.1",
-        "@eslint/config-helpers": "^0.2.1",
-        "@eslint/core": "^0.14.0",
-        "@eslint/eslintrc": "^3.3.1",
-        "@eslint/js": "9.29.0",
-        "@eslint/plugin-kit": "^0.3.1",
+        "@eslint-community/eslint-utils": "^4.8.0",
+        "@eslint-community/regexpp": "^4.12.2",
+        "@eslint/config-array": "^0.23.3",
+        "@eslint/config-helpers": "^0.5.3",
+        "@eslint/core": "^1.1.1",
+        "@eslint/plugin-kit": "^0.6.1",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@humanwhocodes/retry": "^0.4.2",
         "@types/estree": "^1.0.6",
-        "@types/json-schema": "^7.0.15",
-        "ajv": "^6.12.4",
-        "chalk": "^4.0.0",
+        "ajv": "^6.14.0",
         "cross-spawn": "^7.0.6",
         "debug": "^4.3.2",
         "escape-string-regexp": "^4.0.0",
-        "eslint-scope": "^8.4.0",
-        "eslint-visitor-keys": "^4.2.1",
-        "espree": "^10.4.0",
-        "esquery": "^1.5.0",
+        "eslint-scope": "^9.1.2",
+        "eslint-visitor-keys": "^5.0.1",
+        "espree": "^11.2.0",
+        "esquery": "^1.7.0",
         "esutils": "^2.0.2",
         "fast-deep-equal": "^3.1.3",
         "file-entry-cache": "^8.0.0",
@@ -918,8 +817,7 @@
         "imurmurhash": "^0.1.4",
         "is-glob": "^4.0.0",
         "json-stable-stringify-without-jsonify": "^1.0.1",
-        "lodash.merge": "^4.6.2",
-        "minimatch": "^3.1.2",
+        "minimatch": "^10.2.4",
         "natural-compare": "^1.4.0",
         "optionator": "^0.9.3"
       },
@@ -927,7 +825,7 @@
         "eslint": "bin/eslint.js"
       },
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       },
       "funding": {
         "url": "https://eslint.org/donate"
@@ -942,57 +840,59 @@
       }
     },
     "node_modules/eslint-scope": {
-      "version": "8.4.0",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
-      "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-9.1.2.tgz",
+      "integrity": "sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==",
       "license": "BSD-2-Clause",
       "peer": true,
       "dependencies": {
+        "@types/esrecurse": "^4.3.1",
+        "@types/estree": "^1.0.8",
         "esrecurse": "^4.3.0",
         "estraverse": "^5.2.0"
       },
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/eslint-visitor-keys": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
-      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
       "license": "Apache-2.0",
       "peer": true,
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/espree": {
-      "version": "10.4.0",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
-      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-11.2.0.tgz",
+      "integrity": "sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==",
       "license": "BSD-2-Clause",
       "peer": true,
       "dependencies": {
-        "acorn": "^8.15.0",
+        "acorn": "^8.16.0",
         "acorn-jsx": "^5.3.2",
-        "eslint-visitor-keys": "^4.2.1"
+        "eslint-visitor-keys": "^5.0.1"
       },
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/esquery": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.6.0.tgz",
-      "integrity": "sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
       "license": "BSD-3-Clause",
       "peer": true,
       "dependencies": {
@@ -1063,6 +963,24 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
@@ -1120,9 +1038,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "license": "ISC",
       "peer": true
     },
@@ -1164,29 +1082,6 @@
         "node": ">=10.13.0"
       }
     },
-    "node_modules/globals": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
-      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/hasown": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
@@ -1208,23 +1103,6 @@
       "peer": true,
       "engines": {
         "node": ">= 4"
-      }
-    },
-    "node_modules/import-fresh": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
-      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "parent-module": "^1.0.0",
-        "resolve-from": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/imurmurhash": {
@@ -1309,19 +1187,6 @@
       "license": "ISC",
       "peer": true
     },
-    "node_modules/js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "argparse": "^2.0.1"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
-      }
-    },
     "node_modules/json-buffer": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
@@ -1383,21 +1248,14 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/lodash.merge": {
-      "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
-      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
-      "license": "MIT",
-      "peer": true
-    },
     "node_modules/magic-string": {
-      "version": "0.30.17",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.17.tgz",
-      "integrity": "sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==",
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jridgewell/sourcemap-codec": "^1.5.0"
+        "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
     "node_modules/micromatch": {
@@ -1413,17 +1271,32 @@
         "node": ">=8.6"
       }
     },
+    "node_modules/micromatch/node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "license": "ISC",
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "license": "BlueOak-1.0.0",
       "peer": true,
       "dependencies": {
-        "brace-expansion": "^1.1.7"
+        "brace-expansion": "^5.0.5"
       },
       "engines": {
-        "node": "*"
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/ms": {
@@ -1490,19 +1363,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/parent-module": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
-      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "callsites": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -1531,12 +1391,13 @@
       "license": "MIT"
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=8.6"
+        "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
@@ -1563,13 +1424,13 @@
       }
     },
     "node_modules/resolve": {
-      "version": "1.22.10",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.10.tgz",
-      "integrity": "sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==",
+      "version": "1.22.11",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
+      "integrity": "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "is-core-module": "^2.16.0",
+        "is-core-module": "^2.16.1",
         "path-parse": "^1.0.7",
         "supports-preserve-symlinks-flag": "^1.0.0"
       },
@@ -1583,20 +1444,10 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/resolve-from": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
-      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/rollup": {
-      "version": "4.45.1",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.45.1.tgz",
-      "integrity": "sha512-4iya7Jb76fVpQyLoiVpzUrsjQ12r3dM7fIVz+4NwoYvZOShknRmiv+iu9CClZml5ZLGb0XMcYLutK6w9tgxHDw==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.1.tgz",
+      "integrity": "sha512-VmtB2rFU/GroZ4oL8+ZqXgSA38O6GR8KSIvWmEFv63pQ0G6KaBH9s07PO8XTXP4vI+3UJUEypOfjkGfmSBBR0w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1610,26 +1461,31 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.45.1",
-        "@rollup/rollup-android-arm64": "4.45.1",
-        "@rollup/rollup-darwin-arm64": "4.45.1",
-        "@rollup/rollup-darwin-x64": "4.45.1",
-        "@rollup/rollup-freebsd-arm64": "4.45.1",
-        "@rollup/rollup-freebsd-x64": "4.45.1",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.45.1",
-        "@rollup/rollup-linux-arm-musleabihf": "4.45.1",
-        "@rollup/rollup-linux-arm64-gnu": "4.45.1",
-        "@rollup/rollup-linux-arm64-musl": "4.45.1",
-        "@rollup/rollup-linux-loongarch64-gnu": "4.45.1",
-        "@rollup/rollup-linux-powerpc64le-gnu": "4.45.1",
-        "@rollup/rollup-linux-riscv64-gnu": "4.45.1",
-        "@rollup/rollup-linux-riscv64-musl": "4.45.1",
-        "@rollup/rollup-linux-s390x-gnu": "4.45.1",
-        "@rollup/rollup-linux-x64-gnu": "4.45.1",
-        "@rollup/rollup-linux-x64-musl": "4.45.1",
-        "@rollup/rollup-win32-arm64-msvc": "4.45.1",
-        "@rollup/rollup-win32-ia32-msvc": "4.45.1",
-        "@rollup/rollup-win32-x64-msvc": "4.45.1",
+        "@rollup/rollup-android-arm-eabi": "4.60.1",
+        "@rollup/rollup-android-arm64": "4.60.1",
+        "@rollup/rollup-darwin-arm64": "4.60.1",
+        "@rollup/rollup-darwin-x64": "4.60.1",
+        "@rollup/rollup-freebsd-arm64": "4.60.1",
+        "@rollup/rollup-freebsd-x64": "4.60.1",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.1",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.1",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.1",
+        "@rollup/rollup-linux-arm64-musl": "4.60.1",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.1",
+        "@rollup/rollup-linux-loong64-musl": "4.60.1",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.1",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.1",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.1",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.1",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.1",
+        "@rollup/rollup-linux-x64-gnu": "4.60.1",
+        "@rollup/rollup-linux-x64-musl": "4.60.1",
+        "@rollup/rollup-openbsd-x64": "4.60.1",
+        "@rollup/rollup-openharmony-arm64": "4.60.1",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.1",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.1",
+        "@rollup/rollup-win32-x64-gnu": "4.60.1",
+        "@rollup/rollup-win32-x64-msvc": "4.60.1",
         "fsevents": "~2.3.2"
       }
     },
@@ -1652,32 +1508,6 @@
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
       "license": "MIT",
       "peer": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/strip-json-comments": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
-      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
       "engines": {
         "node": ">=8"
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-frontend-rules",
-  "version": "1.1.3",
+  "version": "3.0.0",
   "description": "Reusable ESLint plugin for frontend projects: enforces consistent naming, design, and code quality rules for React and TypeScript, including Typography components, color usage, file naming, export style, and more.",
   "main": "dist/index.js",
   "keywords": [
@@ -18,7 +18,7 @@
     "micromatch": "^4.0.8"
   },
   "peerDependencies": {
-    "eslint": ">=7.0.0"
+    "eslint": ">=9.0.0"
   },
   "files": [
     "dist"


### PR DESCRIPTION
## Summary

Major version upgrade (`v2.x` → `v3.0.0`) that brings full **ESLint v9+ / v10 compatibility**, adds **auto-fixers** to 10 existing rules, and introduces **5 new rules** for better frontend code quality enforcement.

---

## Breaking Changes

- **Minimum ESLint version**: `>=9.0.0` (dropped support for ESLint v8 and below)
- **Package version**: bumped to `3.0.0`

---

## ESLint v9+ / v10 Compatibility

Migrated all deprecated ESLint APIs that were removed in v10:

| Deprecated API | Replacement |
|---|---|
| `context.getFilename()` | `context.filename` |
| `context.getSourceCode()` | `context.sourceCode` |

**Affected rules**: `enforce-typography-components`, `no-direct-colors`, `no-focusable-non-interactive-elements`, `enforce-kebab-case-filenames`, `enforce-alias-import-paths`, `no-default-export`, `enforce-interface-type-naming`, `top-level-const-snake`, `no-inline-arrow-functions-in-jsx`, `no-nested-component`, `interface-type-required-first`, `require-jsdoc-on-component`, `require-jsdoc-on-hook`, `require-jsdoc-on-root-function`

---

## Auto-Fixers Added

Added `meta.fixable: "code"` and `fix()` implementations to existing rules so users can auto-fix violations via `eslint --fix`:

| Rule | Fixer Behavior |
|---|---|
| `no-focusable-non-interactive-elements` | Adds `role="button"`, `tabIndex={0}`, and `onKeyDown` handler |
| `no-default-export` | Converts `export default function Foo` → `export function Foo` |
| `enforce-interface-type-naming` | Adds `I` prefix (interfaces) or `T` prefix (types) |
| `top-level-const-snake` | Converts to `UPPER_SNAKE_CASE` and renames all references in scope |
| `no-unnecessary-fragment` | Unwraps `<>{child}</>` → `{child}` or removes empty fragments |
| `enforce-no-empty-classname-utility` | Removes empty `cn()` / `classNames()` calls and their JSX attribute |
| `interface-type-required-first` | Reorders required fields before optional ones |
| `require-jsdoc-on-component` | Inserts a skeleton JSDoc comment above the component |
| `require-jsdoc-on-hook` | Inserts a skeleton JSDoc comment above the hook |
| `require-jsdoc-on-root-function` | Inserts a skeleton JSDoc comment above the function |

---

## New Rules

| Rule | Category | Fixable | Description |
|---|---|---|---|
| `enforce-boolean-prop-naming` | Naming | ✅ | Enforces boolean props start with `is`, `has`, `should`, `can`, `will`, or `did` prefix |
| `enforce-use-state-naming` | React | ✅ | Enforces `[value, setValue]` destructuring pattern for `useState` |
| `enforce-event-handler-naming` | React | ✅ | Enforces `on*` prefix for JSX callback props and `handle*` for handler functions |
| `enforce-enum-member-naming` | TypeScript | ❌ | Enforces `PascalCase` or `UPPER_SNAKE_CASE` for TypeScript enum members |
| `enforce-testid-naming` | Testing | ✅ | Enforces `kebab-case` for `data-testid` attribute values |

All new rules are included in the `recommended` config as `"warn"`.

---

## Bug Fixes & Cleanup

- **`enforce-no-empty-classname-utility`**: Added missing `meta.schema` (required by ESLint v9+) and removed unused `removeAttribute` dead code
- **`require-jsdoc-on-component`** / **`require-jsdoc-on-hook`**: Removed unused imports (`hasJSDoc`, `isRootLevel`, `micromatch`)

---

## Migration Guide

```diff
# package.json
- "eslint": "^8.0.0"
+ "eslint": ">=9.0.0"

- "eslint-frontend-rules": "^2.x"
+ "eslint-frontend-rules": "^3.0.0"
```

No config changes needed — all existing rule names remain the same. New rules are auto-included in `recommended` as warnings.

---

## Stats

- **21 commits** | **24 files changed** | **+1,023 / -537 lines**
- **23 total rules** (18 existing + 5 new)
- **15 rules** now have auto-fixers
